### PR TITLE
Show errors from contract mutation hooks

### DIFF
--- a/src/contract/ContractEditor.tsx
+++ b/src/contract/ContractEditor.tsx
@@ -339,8 +339,7 @@ const ContractEditor = observer(
 
         if (result.data) {
           if (!isNew) {
-            let nextContract = pickGraphqlData(result.data)
-            setPendingContract(createContractInput(nextContract))
+            setPendingContract(createContractInput(result.data))
           } else {
             goToContract(result.data.id)
           }


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/51
Instead of showing the mutation request result error, show errors from the mutation hooks. This is more dynamic and reactive and doesn't require local state for the error.

Also, it should show errors from both the create and update mutations.