### PR TITLE
Expandable section can be opened / closed from anywhere of the header

### DIFF
--- a/src/common/components/ExpandableSection.tsx
+++ b/src/common/components/ExpandableSection.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { observer } from 'mobx-react-lite'
+import { forOwn } from 'lodash'
 import { ArrowDown } from '../icon/ArrowDown'
 import { SectionHeading } from './Typography'
 
@@ -141,7 +142,22 @@ const ExpandableSection = observer(
   }: PropTypes) => {
     const [expanded, setExpanded] = useState(isExpanded)
 
-    let onChangeExpanded = useCallback(
+    let onClickHeaderRow = useCallback(
+      (e: React.MouseEvent) => {
+        let wasExpandableSectionClicked = false
+        forOwn((e.target as Element).classList, (value) => {
+          if ((value as string).includes('ExpandableSection'))
+            wasExpandableSectionClicked = true
+        })
+
+        if (wasExpandableSectionClicked) {
+          setExpanded((currentVal) => !currentVal)
+        }
+      },
+      [onToggleExpanded]
+    )
+
+    const onClickExpandToggle = useCallback(
       (e: React.MouseEvent) => {
         setExpanded((currentVal) => !currentVal)
         e.stopPropagation()
@@ -160,28 +176,20 @@ const ExpandableSection = observer(
       }
     }, [isExpanded])
 
-    const stopEventPropagation = useCallback((e: React.MouseEvent) => {
-      e.stopPropagation()
-    }, [])
-
     return (
-      <ExpandableBoxView
-        error={error}
-        style={style}
-        className={className}
-        onClick={onChangeExpanded}>
-        <HeaderRow>
+      <ExpandableBoxView error={error} style={style} className={className}>
+        <HeaderRow onClick={onClickHeaderRow}>
           {headerContent && (
             <HeaderContentWrapper expanded={expanded}>
               {typeof headerContent === 'function' ? headerContent(expanded) : headerContent}
             </HeaderContentWrapper>
           )}
-          <ExpandToggle expanded={expanded} onClick={onChangeExpanded}>
+          <ExpandToggle expanded={expanded} onClick={onClickExpandToggle}>
             <ArrowDown width="1rem" height="1rem" fill="var(dark-grey)" />
           </ExpandToggle>
         </HeaderRow>
         {(expanded || !unmountOnClose) && (
-          <ContentWrapper expanded={expanded} onClick={stopEventPropagation}>
+          <ContentWrapper expanded={expanded}>
             {typeof children === 'function' ? children(expanded) : children}
           </ContentWrapper>
         )}

--- a/src/common/components/ExpandableSection.tsx
+++ b/src/common/components/ExpandableSection.tsx
@@ -9,6 +9,7 @@ const ExpandableBoxView = styled.div<{ error: boolean }>`
   margin-top: 1rem;
   border-radius: 0.5rem;
   background: white;
+  cursor: pointer;
 `
 
 export const HeaderRow = styled.div`
@@ -140,9 +141,13 @@ const ExpandableSection = observer(
   }: PropTypes) => {
     const [expanded, setExpanded] = useState(isExpanded)
 
-    let onChangeExpanded = useCallback(() => {
-      setExpanded((currentVal) => !currentVal)
-    }, [onToggleExpanded])
+    let onChangeExpanded = useCallback(
+      (e: React.MouseEvent) => {
+        setExpanded((currentVal) => !currentVal)
+        e.stopPropagation()
+      },
+      [onToggleExpanded]
+    )
 
     useEffect(() => {
       onToggleExpanded(expanded)
@@ -155,8 +160,16 @@ const ExpandableSection = observer(
       }
     }, [isExpanded])
 
+    const stopEventPropagation = useCallback((e: React.MouseEvent) => {
+      e.stopPropagation()
+    }, [])
+
     return (
-      <ExpandableBoxView error={error} style={style} className={className}>
+      <ExpandableBoxView
+        error={error}
+        style={style}
+        className={className}
+        onClick={onChangeExpanded}>
         <HeaderRow>
           {headerContent && (
             <HeaderContentWrapper expanded={expanded}>
@@ -168,7 +181,7 @@ const ExpandableSection = observer(
           </ExpandToggle>
         </HeaderRow>
         {(expanded || !unmountOnClose) && (
-          <ContentWrapper expanded={expanded}>
+          <ContentWrapper expanded={expanded} onClick={stopEventPropagation}>
             {typeof children === 'function' ? children(expanded) : children}
           </ContentWrapper>
         )}

--- a/src/common/components/ExpandableSection.tsx
+++ b/src/common/components/ExpandableSection.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useCallback, useEffect, useState } from 'react'
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { observer } from 'mobx-react-lite'
 import { forOwn } from 'lodash'
@@ -142,24 +142,27 @@ const ExpandableSection = observer(
   }: PropTypes) => {
     const [expanded, setExpanded] = useState(isExpanded)
 
-    let onClickHeaderRow = useCallback(
+    const onClickHeaderRow = useCallback(
       (e: React.MouseEvent) => {
-        let wasExpandableSectionClicked = false
+        let expandableSectionClassCount = 0
         forOwn((e.target as Element).classList, (value) => {
-          if ((value as string).includes('ExpandableSection'))
-            wasExpandableSectionClicked = true
+          if ((value as string).includes('ExpandableSection')) expandableSectionClassCount += 1
         })
+        if (expandableSectionClassCount > 1) {
+          throw 'Multiple ExpandableSection classes found from propagating click event. This might cause errors.'
+        }
 
-        if (wasExpandableSectionClicked) {
+        if (expandableSectionClassCount === 1) {
           setExpanded((currentVal) => !currentVal)
         }
       },
       [onToggleExpanded]
     )
 
-    const onClickExpandToggle = useCallback(
+    const onClickExpandIcon = useCallback(
       (e: React.MouseEvent) => {
         setExpanded((currentVal) => !currentVal)
+        // Prevent parent component from catching the click event
         e.stopPropagation()
       },
       [onToggleExpanded]
@@ -184,7 +187,7 @@ const ExpandableSection = observer(
               {typeof headerContent === 'function' ? headerContent(expanded) : headerContent}
             </HeaderContentWrapper>
           )}
-          <ExpandToggle expanded={expanded} onClick={onClickExpandToggle}>
+          <ExpandToggle expanded={expanded} onClick={onClickExpandIcon}>
             <ArrowDown width="1rem" height="1rem" fill="var(dark-grey)" />
           </ExpandToggle>
         </HeaderRow>

--- a/src/inspection/InspectionUsers.tsx
+++ b/src/inspection/InspectionUsers.tsx
@@ -52,6 +52,10 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
     }
   }, [inspection, user, toggleSubscribed, refetchRelations])
 
+  const stopEventPropagation = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
   return (
     <ExpandableSection
       headerContent={
@@ -62,7 +66,10 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
               style={{ marginLeft: 'auto' }}
               buttonStyle={ButtonStyle.SECONDARY}
               size={ButtonSize.SMALL}
-              onClick={refetchRelations}>
+              onClick={(e: React.MouseEvent) => {
+                refetchRelations()
+                stopEventPropagation(e)
+              }}>
               Päivitä
             </Button>
           </HeaderSection>

--- a/src/inspection/InspectionUsers.tsx
+++ b/src/inspection/InspectionUsers.tsx
@@ -52,10 +52,6 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
     }
   }, [inspection, user, toggleSubscribed, refetchRelations])
 
-  const stopEventPropagation = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-  }, [])
-
   return (
     <ExpandableSection
       headerContent={
@@ -66,10 +62,7 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
               style={{ marginLeft: 'auto' }}
               buttonStyle={ButtonStyle.SECONDARY}
               size={ButtonSize.SMALL}
-              onClick={(e: React.MouseEvent) => {
-                refetchRelations()
-                stopEventPropagation(e)
-              }}>
+              onClick={refetchRelations}>
               Päivitä
             </Button>
           </HeaderSection>


### PR DESCRIPTION
Closes: https://github.com/HSLdevcom/bultti/issues/84

We wanted to implement way to open/close from the whole expandable bar

- we dont want to open/close:
 - from the content of expandable bar
 - from any buttons inside expandable bar, places where this was prevented
    - post-inspections page at UserInspection section)
    - expandable bar's button on the right