### PR TITLE
89 Calendar input improvements

### DIFF
--- a/src/common/input/SelectDate.tsx
+++ b/src/common/input/SelectDate.tsx
@@ -7,6 +7,7 @@ import '../style/reactDates.scss'
 import { DATE_FORMAT } from '../../constants'
 import { format, isAfter, isBefore, isValid, parseISO } from 'date-fns'
 import { isEmpty } from 'lodash'
+import { useAppState, useStateValue } from '../../state/useAppState'
 
 const InputWrapper = styled.div`
   position: relative;
@@ -42,11 +43,13 @@ const SelectDate: React.FC<PropTypes> = observer(
     name,
     alignDatepicker = 'left',
   }) => {
+    let [, setErrorMessage] = useStateValue('errorMessage')
+
     // The local input state.
     let [inputValue, setInputValue] = useState<string>(value)
 
     // Validate the value to be a valid date and between the max and min limits, if any.
-    const getValidDate = useCallback(
+    let getValidDate = useCallback(
       (val: Date | string): Date | null => {
         let dateVal = val instanceof Date ? val : parseISO(val)
 
@@ -104,33 +107,35 @@ const SelectDate: React.FC<PropTypes> = observer(
 
     useEffect(() => {
       let validDate = getValidDate(inputValue)
+
       if (!validDate && !isEmpty(inputValue)) {
         // Should not happen
-        throw `Could not convert inputValue as a valid Date object. Given inputValue: ${inputValue}`
+        setErrorMessage(
+          `Could not convert inputValue as a valid Date object. Given inputValue: ${inputValue}`
+        )
+      } else {
+        let onChangeValue = isEmpty(inputValue) ? '' : format(validDate!, DATE_FORMAT)
+        onChange(onChangeValue)
       }
-      const onChangeValue = isEmpty(inputValue) ? '' : format(validDate!, DATE_FORMAT)
-      onChange(onChangeValue)
     }, [inputValue])
 
     return (
-      <>
-        <InputWrapper>
-          <InputContainer>
-            <Input
-              name={inputName}
-              type="date"
-              subLabel={true}
-              label={label}
-              value={currentValue}
-              onChange={setInputValue}
-              disabled={disabled}
-              min={minDate}
-              max={maxDate}
-              pattern="\d{4}-\d{2}-\d{2}"
-            />
-          </InputContainer>
-        </InputWrapper>
-      </>
+      <InputWrapper>
+        <InputContainer>
+          <Input
+            name={inputName}
+            type="date"
+            subLabel={true}
+            label={label}
+            value={currentValue}
+            onChange={setInputValue}
+            disabled={disabled}
+            min={minDate}
+            max={maxDate}
+            pattern="\d{4}-\d{2}-\d{2}"
+          />
+        </InputContainer>
+      </InputWrapper>
     )
   }
 )

--- a/src/common/input/SelectDate.tsx
+++ b/src/common/input/SelectDate.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import '../style/reactDates.scss'
 import { DATE_FORMAT } from '../../constants'
 import { format, isAfter, isBefore, isValid, parseISO } from 'date-fns'
+import { isEmpty } from 'lodash'
 
 const InputWrapper = styled.div`
   position: relative;
@@ -101,17 +102,15 @@ const SelectDate: React.FC<PropTypes> = observer(
       [label, name]
     )
 
-    const applyInputValue = useCallback(() => {
-      if (inputValue !== value) {
-        let validDate = getValidDate(inputValue)
-
-        if (validDate) {
-          let validDateVal = format(validDate, DATE_FORMAT)
-          onChange(validDateVal)
-          setInputValue(validDateVal)
-        }
+    useEffect(() => {
+      let validDate = getValidDate(inputValue)
+      if (!validDate && !isEmpty(inputValue)) {
+        // Should not happen
+        throw `Could not convert inputValue as a valid Date object. Given inputValue: ${inputValue}`
       }
-    }, [value, inputValue, onChange, getValidDate])
+      const onChangeValue = isEmpty(inputValue) ? '' : format(validDate!, DATE_FORMAT)
+      onChange(onChangeValue)
+    }, [inputValue])
 
     return (
       <>
@@ -124,8 +123,6 @@ const SelectDate: React.FC<PropTypes> = observer(
               label={label}
               value={currentValue}
               onChange={setInputValue}
-              onEnterPress={applyInputValue}
-              onBlur={applyInputValue}
               disabled={disabled}
               min={minDate}
               max={maxDate}

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -27,20 +27,24 @@ export type PropTypes = {
 
 const InspectionConfig: React.FC<PropTypes> = observer(
   ({ saveValues, isEditable, inspection }) => {
-    const getInspectionInputValues = (setFromInspection: Inspection) => {
+    let getInspectionInputValues = (setFromInspection: Inspection) => {
       return {
         name: setFromInspection.name || '',
         inspectionStartDate: setFromInspection.inspectionStartDate || '',
         inspectionEndDate: setFromInspection.inspectionEndDate || '',
       }
     }
-    const initialInspectionInputValues = getInspectionInputValues(inspection)
+
+    let initialInspectionInputValues = getInspectionInputValues(inspection)
+
     let [pendingInspectionInputValues, setPendingInspectionInputValues] = useState<
       InspectionInput
     >(initialInspectionInputValues)
+
     let [oldInspectionInputValues, setOldInspectionInputValues] = useState<InspectionInput>(
       initialInspectionInputValues
     )
+
     let onUpdateValue = useCallback((name, value) => {
       setPendingInspectionInputValues((currentValues) => {
         let nextValues: InspectionInput = { ...currentValues }

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import SelectDate from '../common/input/SelectDate'
 import Input from '../common/input/Input'
-import { isEmpty, isEqual } from 'lodash'
+import { isEqual } from 'lodash'
 import { ControlGroup, FormColumn, InputLabel } from '../common/components/form'
 import { Inspection, InspectionInput, InspectionStatus } from '../schema-types'
 import { MessageContainer, MessageView } from '../common/components/Messages'
@@ -27,13 +27,20 @@ export type PropTypes = {
 
 const InspectionConfig: React.FC<PropTypes> = observer(
   ({ saveValues, isEditable, inspection }) => {
+    const getInspectionInputValues = (setFromInspection: Inspection) => {
+      return {
+        name: setFromInspection.name || '',
+        inspectionStartDate: setFromInspection.inspectionStartDate || '',
+        inspectionEndDate: setFromInspection.inspectionEndDate || '',
+      }
+    }
+    const initialInspectionInputValues = getInspectionInputValues(inspection)
     let [pendingInspectionInputValues, setPendingInspectionInputValues] = useState<
       InspectionInput
-    >({})
-    let [
-      oldInspectionInputValues,
-      setOldInspectionInputValues,
-    ] = useState<InspectionInput | null>(null)
+    >(initialInspectionInputValues)
+    let [oldInspectionInputValues, setOldInspectionInputValues] = useState<InspectionInput>(
+      initialInspectionInputValues
+    )
     let onUpdateValue = useCallback((name, value) => {
       setPendingInspectionInputValues((currentValues) => {
         let nextValues: InspectionInput = { ...currentValues }
@@ -47,21 +54,6 @@ const InspectionConfig: React.FC<PropTypes> = observer(
       setOldInspectionInputValues(pendingInspectionInputValues)
     }, [pendingInspectionInputValues])
 
-    useEffect(() => {
-      if (isEmpty(pendingInspectionInputValues)) {
-        const inspectionInputValues = getInspectionInputValues(inspection)
-        setPendingInspectionInputValues(inspectionInputValues)
-        setOldInspectionInputValues(inspectionInputValues)
-      }
-    }, [inspection])
-
-    let getInspectionInputValues = (setFromInspection: Inspection) => {
-      return {
-        name: setFromInspection.name || '',
-        inspectionStartDate: setFromInspection.inspectionStartDate || '',
-        inspectionEndDate: setFromInspection.inspectionEndDate || '',
-      }
-    }
     let isDirty = useMemo(
       () => !isEqual(oldInspectionInputValues, pendingInspectionInputValues),
       [pendingInspectionInputValues]
@@ -71,7 +63,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(
       <InspectionConfigView>
         {!inspection ? (
           <MessageContainer>
-            <MessageView>Tarkastus ei valittu.</MessageView>
+            <MessageView>Tarkastusta ei ole valittu.</MessageView>
           </MessageContainer>
         ) : (
           <>


### PR DESCRIPTION
Unfortunately opening calendar from the whole input component wasn't possible (tried using ref). If we want this feature (and also possibility to write the date by hand), we should start using some calendar library.

At least date is now properly passing to parent component as soon as it's changed