### PR TITLE
Inspection date range entity & resolvers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,7 @@
 - Use `<button>` element when you have an onClick handler (never use `<div>`)
 - Use `{}` for empty objects
 - Use `''` for empty strings
+
+## Typescript
+
+- Use `unknown` when we don't care what function return type is. Use `void` if you want to indicate that the function doesn't return anything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ## Code conventions
 
-- Use `<button>` element when you have an onClick handler (never use `<div>`)
+- Use `<button>` element when you have an element which the user interacts with through clicking (never use eg. `<div>` unless necessary).
 - Use `{}` for empty objects
 - Use `''` for empty strings
 
 ## Typescript
 
-- Use `unknown` when we don't care what function return type is. Use `void` if you want to indicate that the function doesn't return anything
+- When typing components or other functions which receive function arguments, use `unknown` for the return type of the function argument when the consumer doesn't care about what it returns. Use `void` if you want to indicate that the function doesn't return anything

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ const App: React.FC = observer(() => {
         {requireAdminUser(user) && <InspectionDatePage path="inspection-date" />}
         <UserPage path="user" />
         <OperatorContractsListPage path="contract" />
-        <EditContractPage path="contract/:contractId" />
+        {requireAdminUser(user) && <EditContractPage path="contract/:contractId" />}
         <Todo path="contracts" />
         <Logout path="logout" />
       </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { useStateValue } from './state/useAppState'
 import { HeaderHeading } from './common/components/ExpandableSection'
 import Loading from './common/components/Loading'
 import InspectionDatePage from './page/InspectionDatePage'
+import { requireAdminUser } from './util/userRoles'
 
 const Todo: React.FC<RouteComponentProps> = () => {
   return (
@@ -69,6 +70,7 @@ const Logout: React.FC<RouteComponentProps> = () => {
 
 const App: React.FC = observer(() => {
   const [authState, loading] = useAuth()
+  const [user] = useStateValue('user')
 
   // Listen for the browser close event. Conditionally prompt user when needed.
   let [unsavedFormIds] = useStateValue('unsavedFormIds')
@@ -128,7 +130,7 @@ const App: React.FC = observer(() => {
           path="post-inspection/reports"
           inspectionType={InspectionType.Post}
         />
-        <InspectionDatePage path="inspection-date" />
+        {requireAdminUser(user) && <InspectionDatePage path="inspection-date" />}
         <UserPage path="user" />
         <OperatorContractsListPage path="contract" />
         <EditContractPage path="contract/:contractId" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { pickGraphqlData } from './util/pickGraphqlData'
 import { useStateValue } from './state/useAppState'
 import { HeaderHeading } from './common/components/ExpandableSection'
 import Loading from './common/components/Loading'
+import InspectionDatePage from './page/InspectionDatePage'
 
 const Todo: React.FC<RouteComponentProps> = () => {
   return (
@@ -127,7 +128,7 @@ const App: React.FC = observer(() => {
           path="post-inspection/reports"
           inspectionType={InspectionType.Post}
         />
-
+        <InspectionDatePage path="inspection-date" />
         <UserPage path="user" />
         <OperatorContractsListPage path="contract" />
         <EditContractPage path="contract/:contractId" />

--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -17,7 +17,9 @@ import Dropdown from '../input/Dropdown'
 import { promptUnsavedChangesOnClickEvent } from '../../util/promptUnsavedChanges'
 
 const AppSidebarView = styled.div`
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  height: 100%;
 `
 
 const HSLLogo = styled(HSLLogoNoText)`
@@ -201,6 +203,10 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
           <NavLink to="post-inspection/edit">
             <Plus fill="white" width="1rem" height="1rem" />
             <Text>nav.new.postinspection</Text>
+          </NavLink>
+          <NavLink to="inspection-date">
+            <Plus fill="white" width="1rem" height="1rem" />
+            <Text>nav.category.inspection_date</Text>
           </NavLink>
           <NavLink to="post-inspection/reports">
             <Menu fill="white" width="1rem" height="1rem" />

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -4345,6 +4345,22 @@
             "deprecationReason": null
           },
           {
+            "name": "departureType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "DepartureType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "departureId",
             "description": null,
             "args": [],
@@ -4514,6 +4530,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -7483,6 +7515,18 @@
             "deprecationReason": null
           },
           {
+            "name": "departurePairType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "departureA",
             "description": null,
             "args": [],
@@ -7510,18 +7554,6 @@
                 "name": "Departure",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "departurePairType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -1506,6 +1506,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "allInspectionDates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InspectionDate",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4814,6 +4838,18 @@
           },
           {
             "name": "schemaId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockNumber",
             "description": null,
             "args": [],
             "type": {
@@ -8358,6 +8394,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "InspectionDate",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
         "fields": [
@@ -9946,6 +10041,37 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "createInspectionDate",
+            "description": null,
+            "args": [
+              {
+                "name": "inspectionDate",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InspectionDateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InspectionDate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -10541,6 +10667,45 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "InspectionDateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "startDate",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "endDate",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
             },
             "defaultValue": null
           }

--- a/src/inspection/inspectionDate/InsectionDateList.tsx
+++ b/src/inspection/inspectionDate/InsectionDateList.tsx
@@ -35,7 +35,11 @@ const InspectionDateList: React.FC<PropTypes> = observer(({ inspectionDates, isL
         <>
           {inspectionDates.length === 0 && <Text>inspection_date.list.noResults</Text>}
           {inspectionDates.map((inspectionDate: InspectionDate, index: number) => {
-            return <ListItem key={index}>{inspectionDate.startDate}</ListItem>
+            return (
+              <ListItem key={index}>
+                {inspectionDate.startDate} - {inspectionDate.endDate}
+              </ListItem>
+            )
           })}
         </>
       )}

--- a/src/inspection/inspectionDate/InsectionDateList.tsx
+++ b/src/inspection/inspectionDate/InsectionDateList.tsx
@@ -4,17 +4,23 @@ import { observer } from 'mobx-react-lite'
 import { InspectionDate } from '../../schema-types'
 import { Text } from '../../util/translate'
 import { LoadingDisplay } from '../../common/components/Loading'
+import DateRangeDisplay from '../../common/components/DateRangeDisplay'
 
 const Header = styled.div`
   font-size: 1.2rem;
   margin-bottom: 1rem;
 `
 
+const ListWrapper = styled.div`
+  margin: 0 0 0.5rem;
+`
+
 const ListItem = styled.div`
-  padding: 0.75rem;
-  border-bottom: 1px solid var(--lighter-grey);
-  &:last-of-type {
-    border-bottom: none;
+  margin: 0 -1rem;
+  padding: 0.5rem 1rem;
+
+  &:nth-child(even) {
+    background: var(--white-grey);
   }
 `
 
@@ -25,7 +31,7 @@ interface PropTypes {
 
 const InspectionDateList: React.FC<PropTypes> = observer(({ inspectionDates, isLoading }) => {
   return (
-    <>
+    <ListWrapper>
       <Header>
         <Text>inspection_date.list.header</Text>
       </Header>
@@ -37,13 +43,16 @@ const InspectionDateList: React.FC<PropTypes> = observer(({ inspectionDates, isL
           {inspectionDates.map((inspectionDate: InspectionDate, index: number) => {
             return (
               <ListItem key={index}>
-                {inspectionDate.startDate} - {inspectionDate.endDate}
+                <DateRangeDisplay
+                  startDate={inspectionDate.startDate}
+                  endDate={inspectionDate.endDate}
+                />
               </ListItem>
             )
           })}
         </>
       )}
-    </>
+    </ListWrapper>
   )
 })
 

--- a/src/inspection/inspectionDate/InsectionDateList.tsx
+++ b/src/inspection/inspectionDate/InsectionDateList.tsx
@@ -12,7 +12,7 @@ const Header = styled.div`
 
 const ListItem = styled.div`
   padding: 0.75rem;
-  border-bottom: 1px solid #e7e7e7;
+  border-bottom: 1px solid var(--lighter-grey);
   &:last-of-type {
     border-bottom: none;
   }

--- a/src/inspection/inspectionDate/InsectionDateList.tsx
+++ b/src/inspection/inspectionDate/InsectionDateList.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import styled from 'styled-components'
+import { observer } from 'mobx-react-lite'
+import { InspectionDate } from '../../schema-types'
+import { Text } from '../../util/translate'
+import { LoadingDisplay } from '../../common/components/Loading'
+
+const Header = styled.div`
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+`
+
+const ListItem = styled.div`
+  padding: 0.75rem;
+  border-bottom: 1px solid #e7e7e7;
+  &:last-of-type {
+    border-bottom: none;
+  }
+`
+
+interface PropTypes {
+  inspectionDates: InspectionDate[]
+  isLoading: boolean
+}
+
+const InspectionDateList: React.FC<PropTypes> = observer(({ inspectionDates, isLoading }) => {
+  return (
+    <>
+      <Header>
+        <Text>inspection_date.list.header</Text>
+      </Header>
+      {isLoading ? (
+        <LoadingDisplay />
+      ) : (
+        <>
+          {inspectionDates.length === 0 && <Text>inspection_date.list.noResults</Text>}
+          {inspectionDates.map((inspectionDate: InspectionDate, index: number) => {
+            return <ListItem key={index}>{inspectionDate.startDate}</ListItem>
+          })}
+        </>
+      )}
+    </>
+  )
+})
+
+export default InspectionDateList

--- a/src/inspection/inspectionDate/InspectionDateForm.tsx
+++ b/src/inspection/inspectionDate/InspectionDateForm.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState } from 'react'
+import styled from 'styled-components'
+import { observer } from 'mobx-react-lite'
+import { InspectionDateInput } from '../../schema-types'
+import ItemForm from '../../common/input/ItemForm'
+import { useMutationData } from '../../util/useMutationData'
+import { createInspectionDateMutation } from './inspectionDateQuery'
+import { Text, text } from '../../util/translate'
+import SelectDate from '../../common/input/SelectDate'
+
+const InspectionDateFormContainer = styled.div`
+  background-color: white;
+  padding: 1rem;
+`
+
+const Header = styled.div`
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+`
+
+const inspectionDateLabels = {
+  startDate: text('start_date'),
+  endDate: text('end_date'),
+}
+
+interface PropTypes {
+  closeInspectionDateList: Function
+  refetchInspectionDateList: Function
+}
+
+const InspectionDateForm: React.FC<PropTypes> = observer(
+  ({ closeInspectionDateList, refetchInspectionDateList }) => {
+    const [pendingInspectionDate, setPendingInspectionDate] = useState<
+      Partial<InspectionDateInput>
+    >({
+      startDate: '',
+      endDate: '',
+    })
+    const [createInspectionDate] = useMutationData(createInspectionDateMutation)
+
+    const onDone = async () => {
+      const inspectionDateInput: InspectionDateInput = {
+        startDate: pendingInspectionDate.startDate,
+        endDate: pendingInspectionDate.endDate,
+      }
+      await createInspectionDate({
+        variables: {
+          inspectionDateInput,
+        },
+      })
+      refetchInspectionDateList()
+      closeInspectionDateList()
+    }
+
+    let onChange = (key, nextValue) => {
+      setPendingInspectionDate((currentVal) => {
+        return {
+          ...currentVal,
+          [key]: nextValue,
+        }
+      })
+    }
+
+    const renderInput = (key: string, val: any, onChange) => {
+      return <SelectDate onChange={onChange} value={val as string} label="" name={key} />
+    }
+
+    // TODO: implement better validation
+    let isValid: boolean = useMemo(() => {
+      return (
+        pendingInspectionDate.startDate.length > 0 && pendingInspectionDate.endDate.length > 0
+      )
+    }, [pendingInspectionDate])
+
+    return (
+      <InspectionDateFormContainer>
+        <Header>
+          <Text>inspection_date.form.header</Text>
+        </Header>
+        <ItemForm
+          item={pendingInspectionDate}
+          labels={inspectionDateLabels}
+          renderInput={renderInput}
+          onDone={onDone}
+          onChange={onChange}
+          onCancel={() => closeInspectionDateList()}
+          doneDisabled={!isValid}
+          keyFromItem={(item) => item.id}
+        />
+      </InspectionDateFormContainer>
+    )
+  }
+)
+
+export default InspectionDateForm

--- a/src/inspection/inspectionDate/InspectionDateForm.tsx
+++ b/src/inspection/inspectionDate/InspectionDateForm.tsx
@@ -25,7 +25,7 @@ const inspectionDateLabels = {
 
 interface PropTypes {
   closeInspectionDateList: () => void
-  refetchInspectionDateList: () => void
+  refetchInspectionDateList: () => unknown
 }
 
 const InspectionDateForm: React.FC<PropTypes> = observer(

--- a/src/inspection/inspectionDate/InspectionDateForm.tsx
+++ b/src/inspection/inspectionDate/InspectionDateForm.tsx
@@ -24,8 +24,8 @@ const inspectionDateLabels = {
 }
 
 interface PropTypes {
-  closeInspectionDateList: Function
-  refetchInspectionDateList: Function
+  closeInspectionDateList: () => void
+  refetchInspectionDateList: () => void
 }
 
 const InspectionDateForm: React.FC<PropTypes> = observer(

--- a/src/inspection/inspectionDate/inspectionDateQuery.ts
+++ b/src/inspection/inspectionDate/inspectionDateQuery.ts
@@ -1,0 +1,27 @@
+import { gql } from '@apollo/client'
+
+export const InspectionDateFragment = gql`
+  fragment InspectionDateFragment on InspectionDate {
+    id
+    startDate
+    endDate
+  }
+`
+
+export const allInspectionDatesQuery = gql`
+  query allInspectionDates {
+    allInspectionDates {
+      ...InspectionDateFragment
+    }
+  }
+  ${InspectionDateFragment}
+`
+
+export const createInspectionDateMutation = gql`
+  mutation createInspectionDate($inspectionDateInput: InspectionDateInput!) {
+    createInspectionDate(inspectionDate: $inspectionDateInput) {
+      ...InspectionDateFragment
+    }
+  }
+  ${InspectionDateFragment}
+`

--- a/src/page/InspectionDatePage.tsx
+++ b/src/page/InspectionDatePage.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useState } from 'react'
+import styled from 'styled-components'
+import { observer } from 'mobx-react-lite'
+import { PageTitle } from '../common/components/PageTitle'
+import { Page } from '../common/components/common'
+import { RouteComponentProps } from '@reach/router'
+import InspectionDateForm from '../inspection/inspectionDate/InspectionDateForm'
+import { Button } from '../common/components/Button'
+import InspectionDateList from '../inspection/inspectionDate/InsectionDateList'
+import { useRefetch } from '../util/useRefetch'
+import { useQueryData } from '../util/useQueryData'
+import { allInspectionDatesQuery } from '../inspection/inspectionDate/inspectionDateQuery'
+import { orderBy } from 'lodash'
+import { Text } from '../util/translate'
+
+const InspectionDatesPage = styled.div`
+  padding: 0 1rem 1rem 1rem;
+`
+
+const InspectionDateListWrapper = styled.div`
+  padding: 1rem;
+  background-color: white;
+`
+
+const NewInspectionButtonWrapper = styled.div`
+  margin-top: 1rem;
+`
+
+export type PropTypes = RouteComponentProps
+
+const InspectionDatePage: React.FC<PropTypes> = observer(() => {
+  let loading = false
+  let [isInspectionDateFormVisible, setInspectionDateFormVisibility] = useState<boolean>(false)
+
+  let {
+    data: inspectionDatesQueryResult,
+    loading: areInspectionDatesLoading,
+    refetch: refetchInspectionDates,
+  } = useQueryData(allInspectionDatesQuery, {
+    variables: {},
+  })
+
+  let refetch = useRefetch(refetchInspectionDates)
+
+  let sortedInspectionDates = useMemo(
+    () => orderBy(inspectionDatesQueryResult || [], 'startDate', 'desc'),
+    [inspectionDatesQueryResult]
+  )
+
+  return (
+    <Page>
+      <PageTitle loading={loading} onRefresh={refetch}>
+        <Text>inspection_date.page.header</Text>
+      </PageTitle>
+      <InspectionDatesPage>
+        <InspectionDateListWrapper>
+          <InspectionDateList
+            inspectionDates={sortedInspectionDates}
+            isLoading={areInspectionDatesLoading}
+          />
+          <NewInspectionButtonWrapper>
+            <Button onClick={() => setInspectionDateFormVisibility(true)}>
+              <Text>inspection_date.page.new_inspection_button</Text>
+            </Button>
+          </NewInspectionButtonWrapper>
+        </InspectionDateListWrapper>
+        {isInspectionDateFormVisible && (
+          <InspectionDateForm
+            closeInspectionDateList={() => setInspectionDateFormVisibility(false)}
+            refetchInspectionDateList={refetch}
+          />
+        )}
+      </InspectionDatesPage>
+    </Page>
+  )
+})
+
+export default InspectionDatePage

--- a/src/page/InspectionDatePage.tsx
+++ b/src/page/InspectionDatePage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
 import { PageTitle } from '../common/components/PageTitle'
-import { Page } from '../common/components/common'
+import { Page, PageSection } from '../common/components/common'
 import { RouteComponentProps } from '@reach/router'
 import InspectionDateForm from '../inspection/inspectionDate/InspectionDateForm'
 import { Button } from '../common/components/Button'
@@ -17,10 +17,7 @@ const InspectionDatesPage = styled.div`
   padding: 0 1rem 1rem 1rem;
 `
 
-const InspectionDateListWrapper = styled.div`
-  padding: 1rem;
-  background-color: white;
-`
+const InspectionDateListWrapper = styled(PageSection)``
 
 const NewInspectionButtonWrapper = styled.div`
   margin-top: 1rem;

--- a/src/page/InspectionDatePage.tsx
+++ b/src/page/InspectionDatePage.tsx
@@ -36,9 +36,7 @@ const InspectionDatePage: React.FC<PropTypes> = observer(() => {
     data: inspectionDatesQueryResult,
     loading: areInspectionDatesLoading,
     refetch: refetchInspectionDates,
-  } = useQueryData(allInspectionDatesQuery, {
-    variables: {},
-  })
+  } = useQueryData(allInspectionDatesQuery)
 
   let refetch = useRefetch(refetchInspectionDates)
 

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -56,6 +56,7 @@ export type Query = {
   contractUserRelations: Array<ContractUserRelation>;
   observedExecutionRequirements: Array<ObservedExecutionRequirement>;
   previewObservedRequirement?: Maybe<ObservedExecutionRequirement>;
+  allInspectionDates: Array<InspectionDate>;
 };
 
 
@@ -515,6 +516,7 @@ export type ObservedDeparture = {
   equipmentRotation?: Maybe<Scalars['Int']>;
   isTrunkRoute?: Maybe<Scalars['Boolean']>;
   schemaId?: Maybe<Scalars['String']>;
+  blockNumber?: Maybe<Scalars['String']>;
   procurementUnitId?: Maybe<Scalars['String']>;
   isTracked?: Maybe<Scalars['Boolean']>;
   trackReason: TrackReason;
@@ -880,6 +882,13 @@ export type ProcurementUnitOption = {
   currentContracts?: Maybe<Array<Contract>>;
 };
 
+export type InspectionDate = {
+  __typename?: 'InspectionDate';
+  id: Scalars['ID'];
+  startDate: Scalars['BulttiDate'];
+  endDate: Scalars['BulttiDate'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   updateWeeklyMetersFromSource: ProcurementUnit;
@@ -921,6 +930,7 @@ export type Mutation = {
   createObservedExecutionRequirementsFromPreInspectionRequirements: Array<ObservedExecutionRequirement>;
   removeObservedExecutionRequirementsFromPreInspection: Scalars['Boolean'];
   updateObservedExecutionRequirementValues: ObservedExecutionRequirement;
+  createInspectionDate: InspectionDate;
 };
 
 
@@ -1143,6 +1153,11 @@ export type MutationUpdateObservedExecutionRequirementValuesArgs = {
   requirementId: Scalars['String'];
 };
 
+
+export type MutationCreateInspectionDateArgs = {
+  inspectionDate: InspectionDateInput;
+};
+
 export type ProcurementUnitEditInput = {
   weeklyMeters: Scalars['Float'];
   medianAgeRequirement: Scalars['Float'];
@@ -1211,6 +1226,11 @@ export type ObservedRequirementValueInput = {
   kilometersRequired?: Maybe<Scalars['Float']>;
   quotaRequired?: Maybe<Scalars['Float']>;
   sanctionAmount?: Maybe<Scalars['Float']>;
+};
+
+export type InspectionDateInput = {
+  startDate: Scalars['BulttiDate'];
+  endDate: Scalars['BulttiDate'];
 };
 
 export type Subscription = {

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -477,6 +477,7 @@ export enum TrackReason {
 export type ObservedDeparture = {
   __typename?: 'ObservedDeparture';
   id: Scalars['ID'];
+  departureType: DepartureType;
   departureId: Scalars['String'];
   postInspectionId?: Maybe<Scalars['String']>;
   plannedOperatorId?: Maybe<Scalars['Int']>;
@@ -489,6 +490,7 @@ export type ObservedDeparture = {
   isOriginStop: Scalars['Boolean'];
   isTimingStop: Scalars['Boolean'];
   isDestinationStop: Scalars['Boolean'];
+  date: Scalars['String'];
   departureTime?: Maybe<Scalars['String']>;
   departureDateTime?: Maybe<Scalars['DateTime']>;
   observedDepartureDateTime?: Maybe<Scalars['DateTime']>;
@@ -773,9 +775,9 @@ export type DeparturePair = {
   overlapSecondsA?: Maybe<Scalars['Int']>;
   overlapSecondsB?: Maybe<Scalars['Int']>;
   overlapPlannedBy?: Maybe<Scalars['String']>;
+  departurePairType?: Maybe<Scalars['String']>;
   departureA: Departure;
   departureB: Departure;
-  departurePairType?: Maybe<Scalars['String']>;
 };
 
 export type EmissionClassExecutionItem = {

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -21,6 +21,7 @@
   "nav.category.preinspection": "Ennakkotarkastus",
   "nav.category.postinspection": "Jälkitarkastus",
   "nav.category.reports_contracts": "Sopimusehdot",
+  "nav.category.inspection_date": "Muokkaa tarkistusjaksoja",
   "nav.list.preinspection": "Ennakkotarkastukset",
   "nav.list.postinspection": "Jälkitarkastukset",
   "nav.reports": "Raportit",
@@ -45,6 +46,12 @@
   "inspection.units.hide_all": "Piilota kaikki kilpailukohteet",
   "inspection.pre.new": "Uusi ennakkotarkastus",
   "inspection.post.new": "Uusi jälkitarkastus",
+
+  "inspection_date.page.header": "Muokkaa tarkastusjaksoja",
+  "inspection_date.page.new_inspection_button": "Lisää tarkastusjakso",
+  "inspection_date.list.header": "Nykyiset tarkastusjaksot",
+  "inspection_date.list.noResults": "Tarkastusjaksoja ei löytynyt",
+  "inspection_date.form.header": "Lisää uusi tarkastusjakso",
 
   "Draft": "Muokattavissa",
   "InReview": "Hyväksyttävänä",


### PR DESCRIPTION
**Made a new card: InspectionForms: date options https://github.com/HSLdevcom/bultti/issues/95**
(new card is needed because minStartDate, inspectionStartDate and inspectionEndDate are to be removed)

**Suggestion: new card -> https://github.com/HSLdevcom/bultti/issues/96**

Refactor like this:

```
export function getIsUserAdmin(): boolean {
  let [user] = useStateValue('user')
  return requireUser(user) && user?.role === UserRole.Admin
}
```
(also in backend + other methods too. Move role checking into backend)

**Suggestion 2: new card -> ?**

Validations by using some easilly configurable models like in jore-map-ui:
https://github.com/HSLdevcom/jore-map-ui/blob/develop/src/models/validationModels/lineValidationModel.ts

**Suggestion 3: new card -> ?**

We need a way to pass dates to the calendar that are unselectable. I doubt that the current native date input can pull this off. Have to switch to using some calendary library I think.


