### PR TITLE
HSLdevcom/bultti#88 Remove and refactor redundant old-states from forms.

### DIFF
--- a/src/equipmentCatalogue/EquipmentCatalogue.tsx
+++ b/src/equipmentCatalogue/EquipmentCatalogue.tsx
@@ -24,7 +24,7 @@ import {
 import AddEquipment from '../equipment/AddEquipment'
 import { MessageView } from '../common/components/Messages'
 import { text } from '../util/translate'
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 
 const EquipmentCatalogueView = styled.div``
 
@@ -61,7 +61,6 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
     const [pendingCatalogue, setPendingCatalogue] = useState<EquipmentCatalogueInput | null>(
       null
     )
-    const [oldCatalogue, setOldCatalogue] = useState<EquipmentCatalogueInput | null>(null)
 
     let { removeAllEquipment, addEquipment, addBatchEquipment } = useEquipmentCrud(
       catalogue,
@@ -70,12 +69,6 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
 
     const [createCatalogue] = useMutationData(createEquipmentCatalogueMutation)
     const [updateCatalogue] = useMutationData(updateEquipmentCatalogueMutation)
-
-    useEffect(() => {
-      if (!oldCatalogue) {
-        setOldCatalogue(pendingCatalogue)
-      }
-    }, [pendingCatalogue])
 
     const addDraftCatalogue = useCallback(() => {
       if (!editable) {
@@ -115,7 +108,6 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
       }
 
       setPendingCatalogue(null)
-      setOldCatalogue(pendingCatalogue)
 
       if (catalogue && catalogueEditMode.current === CatalogueEditMode.UPDATE) {
         await updateCatalogue({
@@ -164,7 +156,15 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
       [equipment]
     )
 
-    let isDirty = !isEqual(oldCatalogue, pendingCatalogue)
+    let isDirty = useMemo(
+      () =>
+        !isEqual(
+          // Pick only props existing on the pending catalogue input for comparison
+          pick(catalogue, Object.keys(pendingCatalogue || {})),
+          pendingCatalogue
+        ),
+      [catalogue, pendingCatalogue]
+    )
 
     return (
       <EquipmentCatalogueView>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import SelectDate from '../common/input/SelectDate'
 import Input from '../common/input/Input'
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 import { ControlGroup, FormColumn, InputLabel } from '../common/components/form'
 import { Inspection, InspectionInput, InspectionStatus } from '../schema-types'
 import { MessageContainer, MessageView } from '../common/components/Messages'
@@ -59,7 +59,12 @@ const InspectionConfig: React.FC<PropTypes> = observer(
     }, [pendingInspectionInputValues])
 
     let isDirty = useMemo(
-      () => !isEqual(oldInspectionInputValues, pendingInspectionInputValues),
+      () =>
+        !isEqual(
+          // Pick only props existing on the pending inspection input for comparison
+          pick(inspection, Object.keys(pendingInspectionInputValues)),
+          pendingInspectionInputValues
+        ),
       [pendingInspectionInputValues]
     )
 

--- a/src/procurementUnit/ProcurementUnitFormInput.tsx
+++ b/src/procurementUnit/ProcurementUnitFormInput.tsx
@@ -5,7 +5,6 @@ import { TextInput } from '../common/input/Input'
 
 export const FormInput = styled(TextInput).attrs(() => ({ theme: 'light' }))`
   font-family: var(--font-family);
-  font-size: 0.75rem;
 `
 
 type ValueType = string | number
@@ -18,32 +17,34 @@ export type PropTypes = {
 
 const numericTypes = ['weeklyMeters', 'medianAgeRequirement']
 
-const ProcurementUnitFormInput: React.FC<PropTypes> = observer(({ value, valueName, onChange }) => {
-  const valueIsNumeric = numericTypes.includes(valueName)
+const ProcurementUnitFormInput: React.FC<PropTypes> = observer(
+  ({ value, valueName, onChange }) => {
+    const valueIsNumeric = numericTypes.includes(valueName)
 
-  const onChangeValue = useCallback(
-    (e) => {
-      let nextValue = e.target.value
+    const onChangeValue = useCallback(
+      (e) => {
+        let nextValue = e.target.value
 
-      if (valueIsNumeric) {
-        const floatVal = parseFloat(nextValue)
-        nextValue = !nextValue || isNaN(floatVal) ? '' : floatVal
-      }
+        if (valueIsNumeric) {
+          const floatVal = parseFloat(nextValue)
+          nextValue = !nextValue || isNaN(floatVal) ? '' : floatVal
+        }
 
-      onChange(nextValue, valueName)
-    },
-    [onChange, valueIsNumeric]
-  )
+        onChange(nextValue, valueName)
+      },
+      [onChange, valueIsNumeric]
+    )
 
-  return (
-    <FormInput
-      type={valueIsNumeric ? 'number' : 'text'}
-      step={valueIsNumeric ? 0.1 : 1}
-      value={value}
-      onChange={onChangeValue}
-      name={valueName}
-    />
-  )
-})
+    return (
+      <FormInput
+        type={valueIsNumeric ? 'number' : 'text'}
+        step={valueIsNumeric ? 0.1 : 1}
+        value={value}
+        onChange={onChangeValue}
+        name={valueName}
+      />
+    )
+  }
+)
 
 export default ProcurementUnitFormInput

--- a/src/procurementUnit/ProcurementUnitItem.tsx
+++ b/src/procurementUnit/ProcurementUnitItem.tsx
@@ -9,7 +9,7 @@ import {
   ProcurementUnitEditInput,
   ValidationErrorData,
 } from '../schema-types'
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 import { round } from '../util/round'
 import EquipmentCatalogue from '../equipmentCatalogue/EquipmentCatalogue'
 import { isBetween } from '../util/isBetween'
@@ -113,10 +113,6 @@ const ProcurementUnitItemContent = observer(
       pendingProcurementUnit,
       setPendingProcurementUnit,
     ] = useState<ProcurementUnitEditInput | null>(null)
-    const [
-      oldProcurementUnit,
-      setOldProcurementUnit,
-    ] = useState<ProcurementUnitEditInput | null>(null)
 
     // Get the operating units for the selected operator.
     const { data: procurementUnit, loading, refetch: refetchUnitData } =
@@ -160,7 +156,6 @@ const ProcurementUnitItemContent = observer(
         }
 
         setPendingProcurementUnit(inputRow)
-        setOldProcurementUnit(inputRow)
       }
     }, [procurementUnit, catalogueEditable])
 
@@ -229,6 +224,15 @@ const ProcurementUnitItemContent = observer(
       return <ProcurementUnitFormInput value={val} valueName={key} onChange={onChange} />
     }, [])
 
+    let isDirty = useMemo(
+      () =>
+        !isEqual(
+          pick(procurementUnit, Object.keys(pendingProcurementUnit || {})),
+          pendingProcurementUnit
+        ),
+      [procurementUnit, pendingProcurementUnit]
+    )
+
     return (
       <ContentWrapper>
         <LoadingDisplay loading={loading} />
@@ -265,28 +269,26 @@ const ProcurementUnitItemContent = observer(
                 </ValueDisplay>
               </>
             ) : catalogueEditable ? (
-              <>
-                <ItemForm
-                  item={pendingProcurementUnit}
-                  labels={procurementUnitLabels}
-                  onChange={onChangeProcurementUnit}
-                  onDone={onSaveProcurementUnit}
-                  onCancel={onCancelPendingUnit}
-                  isDirty={!isEqual(oldProcurementUnit, pendingProcurementUnit)}
-                  doneLabel="Tallenna"
-                  doneDisabled={Object.values(pendingProcurementUnit).some(
-                    (val: number | string | undefined | null) =>
-                      val === null || typeof val === 'undefined' || val === ''
-                  )}
-                  renderInput={renderProcurementItemInput}>
-                  <Button
-                    size={ButtonSize.SMALL}
-                    buttonStyle={ButtonStyle.SECONDARY}
-                    onClick={onUpdateWeeklyMeters}>
-                    Päivitä suoritteet JOREsta
-                  </Button>
-                </ItemForm>
-              </>
+              <ItemForm
+                item={pendingProcurementUnit}
+                labels={procurementUnitLabels}
+                onChange={onChangeProcurementUnit}
+                onDone={onSaveProcurementUnit}
+                onCancel={onCancelPendingUnit}
+                isDirty={isDirty}
+                doneLabel="Tallenna"
+                doneDisabled={Object.values(pendingProcurementUnit).some(
+                  (val: number | string | undefined | null) =>
+                    val === null || typeof val === 'undefined' || val === ''
+                )}
+                renderInput={renderProcurementItemInput}>
+                <Button
+                  size={ButtonSize.SMALL}
+                  buttonStyle={ButtonStyle.SECONDARY}
+                  onClick={onUpdateWeeklyMeters}>
+                  Päivitä suoritteet JOREsta
+                </Button>
+              </ItemForm>
             ) : null}
             <CatalogueWrapper isInvalid={catalogueInvalid}>
               <SubHeading>Kalustoluettelo</SubHeading>


### PR DESCRIPTION
I noticed some forms have "old" states for input values, which were used to determine if the form is dirty. Since the "old" state is already available in each component as the main entity that the component is rendering, a separate old state is not needed.

Generally, state should be used sparingly and only when necessary.