### PR TITLE
105 fix procurement unit issues 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,5 @@
 ## Typescript
 
 - When typing components or other functions which receive function arguments, use `unknown` for the return type of the function argument when the consumer doesn't care about what it returns. Use `void` if you want to indicate that the function doesn't return anything
+
+- When importing type from schema-types, use a `Type` suffix in the type name: `<typeName>Type`

--- a/src/contract/ContractEditor.tsx
+++ b/src/contract/ContractEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
-import { Contract, ContractInput } from '../schema-types'
+import { Contract as ContractType, ContractInput } from '../schema-types'
 import ItemForm, { FieldLabel, FieldValueDisplay } from '../common/input/ItemForm'
 import { useMutationData } from '../util/useMutationData'
 import {
@@ -32,6 +32,7 @@ import { useUploader } from '../util/useUploader'
 import { SubHeading } from '../common/components/Typography'
 import Table from '../common/components/Table'
 import { text, Text } from '../util/translate'
+import { navigateWithQueryString } from '../util/urlValue'
 
 const ContractEditorView = styled.div`
   padding: 0 1rem;
@@ -55,14 +56,14 @@ const ExpandableFormSectionHeading = styled(HeaderBoldHeading)`
 `
 
 export type PropTypes = {
-  contract: Contract
+  contract: ContractType
   onReset: () => unknown
   onRefresh: () => unknown
   isNew?: boolean
   editable: boolean
 }
 
-function createContractInput(contract: Contract): ContractInput {
+function createContractInput(contract: ContractType): ContractInput {
   return {
     id: contract.id,
     description: contract.description ? contract.description : '',
@@ -369,19 +370,27 @@ const ContractEditor = observer(
       onReset()
     }, [contract, onReset])
 
-    let [removeContract, { loading: removeLoading }] = useMutationData(removeContractMutation)
+    let [removeContract, { loading: removeLoading }] = useMutationData<ContractType>(
+      removeContractMutation
+    )
 
-    let execRemove = useCallback(async () => {
-      if (!isNew && confirm(text('contract_form.remove_confirm'))) {
+    let execRemoveContract = useCallback(async () => {
+      if (isNew) {
+        // Go back to the previous page
+        navigateWithQueryString('/contract', { replace: true })
+        return
+      }
+      if (confirm(text('contract_form.remove_confirm'))) {
         let result = await removeContract({
           variables: {
             contractId: contract.id,
           },
         })
 
-        if (pickGraphqlData(result.data)) {
-          onRefresh()
-        }
+        if (result.errors && result.errors.length > 0) return
+
+        // Go back to the previous page
+        navigateWithQueryString('/contract', { replace: true })
       }
     }, [removeContract, contract, isNew, onRefresh])
 
@@ -397,7 +406,7 @@ const ContractEditor = observer(
             style={{ marginLeft: 'auto', marginRight: 0 }}
             buttonStyle={ButtonStyle.REMOVE}
             size={ButtonSize.MEDIUM}
-            onClick={execRemove}>
+            onClick={execRemoveContract}>
             <Text>contract_form.remove</Text>
           </Button>
         </FlexRow>

--- a/src/contract/ContractEditor.tsx
+++ b/src/contract/ContractEditor.tsx
@@ -371,7 +371,17 @@ const ContractEditor = observer(
     }, [contract, onReset])
 
     let [removeContract, { loading: removeLoading }] = useMutationData<ContractType>(
-      removeContractMutation
+      removeContractMutation,
+      {
+        refetchQueries: [
+          {
+            query: contractsQuery,
+            variables: {
+              operatorId: contract.operatorId,
+            },
+          },
+        ],
+      }
     )
 
     let execRemoveContract = useCallback(async () => {
@@ -387,7 +397,9 @@ const ContractEditor = observer(
           },
         })
 
-        if (result.errors && result.errors.length > 0) return
+        if (result.errors && result.errors.length !== 0) {
+          return
+        }
 
         // Go back to the previous page
         navigateWithQueryString('/contract', { replace: true })

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -145,6 +145,34 @@
             "description": null,
             "args": [
               {
+                "name": "endDate",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "BulttiDate",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "startDate",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "BulttiDate",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "procurementUnitId",
                 "description": null,
                 "type": {
@@ -4292,6 +4320,22 @@
             "deprecationReason": null
           },
           {
+            "name": "departureType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "DepartureType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "departureId",
             "description": null,
             "args": [],
@@ -4729,30 +4773,6 @@
           },
           {
             "name": "blockNumber",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "blockJourneyStartTime",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "blockJourneyEndTime",
             "description": null,
             "args": [],
             "type": {

--- a/src/page/ContractPage.tsx
+++ b/src/page/ContractPage.tsx
@@ -86,7 +86,6 @@ const OperatorContractsListPage = observer(({ children }: PropTypes) => {
     variables: {
       operatorId: operator?.id,
     },
-    fetchPolicy: 'no-cache', // TODO: find a better way than this (this way contracts get refetched after removing one)
   })
 
   let refetch = useRefetch(refetchContracts)

--- a/src/page/ContractPage.tsx
+++ b/src/page/ContractPage.tsx
@@ -86,6 +86,7 @@ const OperatorContractsListPage = observer(({ children }: PropTypes) => {
     variables: {
       operatorId: operator?.id,
     },
+    fetchPolicy: 'no-cache', // TODO: find a better way than this (this way contracts get refetched after removing one)
   })
 
   let refetch = useRefetch(refetchContracts)

--- a/src/page/SelectInspectionPage.tsx
+++ b/src/page/SelectInspectionPage.tsx
@@ -18,7 +18,7 @@ const SelectInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) 
   var [season] = useStateValue('globalSeason')
   var [operator] = useStateValue('globalOperator')
 
-  let { data: inspections, loading, refetch } = useQueryData<Inspection>(
+  let { data: inspections, loading, refetch } = useQueryData<Inspection[]>(
     currentPreInspectionsByOperatorAndSeasonQuery,
     {
       skip: !operator?.id || !season?.id,

--- a/src/preInspection/PreInspectionEditor.tsx
+++ b/src/preInspection/PreInspectionEditor.tsx
@@ -46,7 +46,6 @@ const PreInspectionEditor: React.FC<PreInspectionProps> = observer(
         <SectionHeading theme="light">Kilpailukohteet</SectionHeading>
         {inspection && (
           <ProcurementUnits
-            onUpdate={refetchData}
             requirementsEditable={isEditable}
             getErrorsById={getByObjectId}
             operatorId={inspection.operatorId!}

--- a/src/procurementUnit/ProcurementUnitItem.tsx
+++ b/src/procurementUnit/ProcurementUnitItem.tsx
@@ -24,6 +24,7 @@ export type PropTypes = {
   procurementUnit: ProcurementUnitType
   expanded?: boolean
   startDate: string
+  endDate: string
   catalogueEditable: boolean
   requirementsEditable: boolean
   showExecutionRequirements: boolean
@@ -43,6 +44,7 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
     requirementsEditable,
     showExecutionRequirements,
     startDate,
+    endDate,
     procurementUnit,
     expanded = true,
     className,
@@ -134,6 +136,7 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
                 isVisible={itemIsExpanded}
                 showExecutionRequirements={showExecutionRequirements}
                 startDate={startDate}
+                endDate={endDate}
                 procurementUnitId={procurementUnit.id}
                 requirementsEditable={requirementsEditable}
                 catalogueEditable={catalogueEditable}

--- a/src/procurementUnit/ProcurementUnitItem.tsx
+++ b/src/procurementUnit/ProcurementUnitItem.tsx
@@ -28,7 +28,6 @@ export type PropTypes = {
   requirementsEditable: boolean
   showExecutionRequirements: boolean
   className?: string
-  onUpdate?: () => unknown
   validationErrors: ValidationErrorData[]
 }
 
@@ -47,7 +46,6 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
     procurementUnit,
     expanded = true,
     className,
-    onUpdate,
     validationErrors = [],
   }) => {
     const { currentContracts = [], routes = [] } = procurementUnit || {}
@@ -133,7 +131,6 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
             }>
             {(itemIsExpanded: boolean) => (
               <ProcurementUnitItemContent
-                onUpdate={onUpdate}
                 isVisible={itemIsExpanded}
                 showExecutionRequirements={showExecutionRequirements}
                 startDate={startDate}

--- a/src/procurementUnit/ProcurementUnitItemContent.tsx
+++ b/src/procurementUnit/ProcurementUnitItemContent.tsx
@@ -61,6 +61,7 @@ const procurementUnitLabels = {
 type ContentPropTypes = {
   showExecutionRequirements: boolean
   startDate: string
+  endDate: string
   procurementUnitId: string
   catalogueEditable: boolean
   requirementsEditable: boolean
@@ -73,6 +74,7 @@ const ProcurementUnitItemContent = observer(
   ({
     showExecutionRequirements,
     startDate,
+    endDate,
     procurementUnitId,
     catalogueEditable,
     requirementsEditable,
@@ -90,6 +92,8 @@ const ProcurementUnitItemContent = observer(
         skip: !procurementUnitId || !isVisible,
         variables: {
           procurementUnitId,
+          startDate,
+          endDate,
         },
       }) || {}
 

--- a/src/procurementUnit/ProcurementUnitItemContent.tsx
+++ b/src/procurementUnit/ProcurementUnitItemContent.tsx
@@ -65,7 +65,6 @@ type ContentPropTypes = {
   catalogueEditable: boolean
   requirementsEditable: boolean
   isVisible: boolean
-  onUpdate?: () => unknown
   catalogueInvalid: boolean
   requirementsInvalid: boolean
 }
@@ -78,7 +77,6 @@ const ProcurementUnitItemContent = observer(
     catalogueEditable,
     requirementsEditable,
     isVisible,
-    onUpdate,
     catalogueInvalid,
     requirementsInvalid,
   }: ContentPropTypes) => {
@@ -86,7 +84,6 @@ const ProcurementUnitItemContent = observer(
       pendingProcurementUnit,
       setPendingProcurementUnit,
     ] = useState<ProcurementUnitEditInput | null>(null)
-
     // Get the operating units for the selected operator.
     const { data: procurementUnit, loading, refetch: refetchUnitData } =
       useQueryData<ProcurementUnitType>(procurementUnitQuery, {
@@ -99,13 +96,8 @@ const ProcurementUnitItemContent = observer(
     let refetch = useRefetch(refetchUnitData)
 
     let updateUnit = useCallback(() => {
-      console.log('at updateUnit')
       refetch()
-
-      if (onUpdate) {
-        onUpdate()
-      }
-    }, [refetch, onUpdate])
+    }, [refetch])
 
     // Find the currently active Equipment Catalogue for the Operating Unit
     const catalogues: EquipmentCatalogueType[] = useMemo(() => {
@@ -216,7 +208,6 @@ const ProcurementUnitItemContent = observer(
           <>
             {showExecutionRequirements && hasEquipment && (
               <ProcurementUnitExecutionRequirement
-                onUpdate={onUpdate}
                 isEditable={requirementsEditable}
                 procurementUnit={procurementUnit}
                 valid={!requirementsInvalid}

--- a/src/procurementUnit/ProcurementUnits.tsx
+++ b/src/procurementUnit/ProcurementUnits.tsx
@@ -9,7 +9,7 @@ import { procurementUnitsQuery } from './procurementUnitsQuery'
 import { LoadingDisplay } from '../common/components/Loading'
 import { InspectionContext } from '../inspection/InspectionContext'
 import { MessageView } from '../common/components/Messages'
-import { ValidationErrorData } from '../schema-types'
+import { ProcurementUnit as ProcurementUnitType, ValidationErrorData } from '../schema-types'
 import { text, Text } from '../util/translate'
 
 const ProcurementUnitsView = styled(TransparentPageSection)``
@@ -41,10 +41,10 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
 
     // Get the operating units for the selected operator.
     const {
-      data: procurementUnitsData,
+      data: procurementUnits = [],
       loading: procurementUnitsLoading,
       refetch,
-    } = useQueryData(procurementUnitsQuery, {
+    } = useQueryData<ProcurementUnitType[]>(procurementUnitsQuery, {
       skip: !operatorId,
       variables: {
         operatorId: operatorId,
@@ -52,8 +52,6 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
         endDate,
       },
     })
-
-    const procurementUnits = procurementUnitsData || []
 
     return (
       <ProcurementUnitsView>
@@ -92,6 +90,7 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
                   showExecutionRequirements={showExecutionRequirements}
                   key={procurementUnit.id}
                   startDate={startDate}
+                  endDate={endDate}
                   procurementUnit={procurementUnit}
                   expanded={procurementUnitsExpanded}
                 />

--- a/src/procurementUnit/ProcurementUnits.tsx
+++ b/src/procurementUnit/ProcurementUnits.tsx
@@ -19,19 +19,11 @@ export type PropTypes = {
   startDate: string
   endDate: string
   requirementsEditable: boolean
-  onUpdate?: () => unknown
   getErrorsById?: (objectId: string) => ValidationErrorData[]
 }
 
 const ProcurementUnits: React.FC<PropTypes> = observer(
-  ({
-    getErrorsById,
-    requirementsEditable = true,
-    onUpdate,
-    operatorId,
-    startDate,
-    endDate,
-  }) => {
+  ({ getErrorsById, requirementsEditable = true, operatorId, startDate, endDate }) => {
     const inspection = useContext(InspectionContext)
 
     let catalogueEditable = !inspection
@@ -95,7 +87,6 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
               return (
                 <ProcurementUnitItem
                   validationErrors={unitErrors}
-                  onUpdate={onUpdate}
                   requirementsEditable={requirementsEditable}
                   catalogueEditable={catalogueEditable}
                   showExecutionRequirements={showExecutionRequirements}

--- a/src/procurementUnit/procurementUnitsQuery.ts
+++ b/src/procurementUnit/procurementUnitsQuery.ts
@@ -49,8 +49,16 @@ export const procurementUnitsQuery = gql`
 `
 
 export const procurementUnitQuery = gql`
-  query procurementUnit($procurementUnitId: String!) {
-    procurementUnit(procurementUnitId: $procurementUnitId) {
+  query procurementUnit(
+    $procurementUnitId: String!
+    $startDate: BulttiDate!
+    $endDate: BulttiDate!
+  ) {
+    procurementUnit(
+      procurementUnitId: $procurementUnitId
+      startDate: $startDate
+      endDate: $endDate
+    ) {
       ...ProcurementUnitFragment
       equipmentCatalogues {
         id

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -76,6 +76,8 @@ export type QuerySeasonsArgs = {
 
 
 export type QueryProcurementUnitArgs = {
+  endDate: Scalars['BulttiDate'];
+  startDate: Scalars['BulttiDate'];
   procurementUnitId: Scalars['String'];
 };
 
@@ -467,6 +469,7 @@ export enum TrackReason {
 export type ObservedDeparture = {
   __typename?: 'ObservedDeparture';
   id: Scalars['ID'];
+  departureType: DepartureType;
   departureId: Scalars['String'];
   postInspectionId?: Maybe<Scalars['String']>;
   plannedOperatorId?: Maybe<Scalars['Int']>;
@@ -502,8 +505,6 @@ export type ObservedDeparture = {
   isTrunkRoute?: Maybe<Scalars['Boolean']>;
   schemaId?: Maybe<Scalars['String']>;
   blockNumber?: Maybe<Scalars['String']>;
-  blockJourneyStartTime?: Maybe<Scalars['String']>;
-  blockJourneyEndTime?: Maybe<Scalars['String']>;
   procurementUnitId?: Maybe<Scalars['String']>;
   isTracked?: Maybe<Scalars['Boolean']>;
   trackReason: TrackReason;

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -46,7 +46,7 @@
   "contract_form.toml_read_error_failed": "Toml-tiedoston lukeminen epäonnistui. Palvelimen antaman virhe: ",
   "contract_form.current_contract": "Nykyiset ehdot",
   "contract_form.procurement_units": "Kilpailukohteet",
-  "contract_form.no_loaded_contract_file": "Ei ladattua tiedostoa.",
+  "contract_form.no_loaded_contract_file": "Ei tallennettua tiedostoa.",
   "contract_form.label.startDate": "Sopimusehdot alkaa",
   "contract_form.label.endDate": "Sopimusehdot loppuu",
   "contract_form.label.description": "Sopimusehdot loppuu",

--- a/src/util/urlValue.ts
+++ b/src/util/urlValue.ts
@@ -130,7 +130,13 @@ export const pathWithQuery = (path = '', location?: Location | string) => {
   return `${path}?${currentQuery.toString()}`
 }
 
-export const navigateWithQueryString = (navigateTo, opts?: any) => {
+/**
+ * @param {string} navigateTo - Path to navigate into (query string gets included)
+ * @param {Object} opts - Optional options
+ * @param {boolean} opts.replace - if true, the current entry in the history stack will be replaced with the new one. If empty/false, a call to navigate will push a new entry into the history stack so the user can click the back button to get back to the previous page.
+ * @returns {void}
+ */
+export const navigateWithQueryString = (navigateTo: string, opts?: any) => {
   let path = pathWithQuery(navigateTo, history.location)
   return navigate(path, opts)
 }

--- a/src/util/useQueryData.ts
+++ b/src/util/useQueryData.ts
@@ -13,7 +13,7 @@ const defaultOptions = {
   notifyOnNetworkStatusChange: true,
 }
 
-export const useQueryData = <TData extends {} = {}, TVariables = OperationVariables>(
+export const useQueryData = <TData extends {} = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options: QueryHookOptions<TData, TVariables> & { pickData?: string } = {},
   subscriber?: { document: DocumentNode; variables?: TVariables }
@@ -71,7 +71,7 @@ export const useQueryData = <TData extends {} = {}, TVariables = OperationVariab
 
   // Pick the result data from the returned data structure.
   // Return prevData if the result is not yet loaded.
-  let pickedData = useMemo(() => {
+  let pickedData = useMemo<TData>(() => {
     let resultData = pickGraphqlData(data, pickData)
 
     if (!resultData) {


### PR DESCRIPTION
Relates to: https://github.com/HSLdevcom/bultti/issues/105

1. Procurement units are not listed before the contract is saved

* Showing "Ei ladattua tiedostoa" text when creating new

2.Editing procurement unit will make the unit's contract info disappear from the expandable box header

To fix this, startDate and endDate needed to be added to the single procurementQuery.

A better solution could be to remove currentContracts and make a resolver in ContractResolver to get them. I think that is out of the scope this card though, card -> ?

Btw, I don't really like that startDate and endDate are transfered through the whole component tree, that's ugly. What if we used a store / react context for each page so that you could set a variable there to be accessed from anywhere in the same page?
Card -> ?

3. Remove contract not working

Now you can remove:
- an existing contract
- a new unsaved contract
..and it goes to the /contract page

Btw, I left a TODO there as you can see
fetchPolicy: 'no-cache', // TODO: find a better way than this 
If you have an idea how to do it without using this fetchPolicy, I'm happy to fix it

Also note: Added a small convention to the CONTRIBUTING file