### PR TITLE
WIP: 95 fix date fields into dropdown

### DIFF
--- a/src/common/components/DateRangeDisplay.tsx
+++ b/src/common/components/DateRangeDisplay.tsx
@@ -1,8 +1,8 @@
 import React, { CSSProperties } from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
-import { format, isSameDay, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../../constants'
+import { isSameDay, parseISO } from 'date-fns'
+import { getReadableDate } from '../../util/formatDate'
 
 const DateRangeDisplayView = styled.div`
   display: flex;
@@ -43,9 +43,9 @@ const DateRangeDisplay = observer(({ startDate, endDate, className, style }: Pro
 
   return (
     <DateRangeDisplayView className={className} style={style}>
-      <StartDate>{format(startDateObj, READABLE_DATE_FORMAT)}</StartDate>
+      <StartDate>{getReadableDate(startDateObj)}</StartDate>
       {!isSameDay(startDateObj, endDateObj) && (
-        <EndDate>{format(endDateObj, READABLE_DATE_FORMAT)}</EndDate>
+        <EndDate>{getReadableDate(endDateObj)}</EndDate>
       )}
     </DateRangeDisplayView>
   )

--- a/src/common/input/Dropdown.tsx
+++ b/src/common/input/Dropdown.tsx
@@ -34,13 +34,11 @@ const SelectButton = styled(Button).attrs({ size: ButtonSize.MEDIUM })<{
   font-size: 1rem;
   justify-content: flex-start;
   display: flex;
-
   svg {
     display: ${(p) => (p.disabled ? 'none' : 'block')};
     margin-left: auto;
     margin-right: 0;
   }
-
   ${(p) =>
     !p.disabled
       ? css`
@@ -48,7 +46,6 @@ const SelectButton = styled(Button).attrs({ size: ButtonSize.MEDIUM })<{
             background: ${(p) => (p.theme === 'light' ? '#fafafa' : 'var(--lighter-grey)')};
             color: var(--dark-grey);
             border-color: var(--blue);
-
             svg * {
               fill: ${(p) => (p.theme === 'light' ? 'var(--blue)' : 'var(--dark-grey)')};
             }
@@ -86,11 +83,11 @@ const DropdownItem = styled.li<{ highlighted: boolean }>`
 export type DropdownProps = {
   disabled?: boolean
   label?: string
-  items: any[]
+  items: any[] // any object (remember to pass itemToString, itemToLabel), array, { field, value } object
   onSelect: (selectedItem: any | null) => unknown
-  itemToString?: string | ((item: any | null) => string)
-  itemToLabel?: string | ((item: any | null) => string)
-  selectedItem?: any
+  itemToString?: string | ((item: any | null) => string) // property of given object to get value from
+  itemToLabel?: string | ((item: any | null) => string) // property of given object to get label from
+  selectedItem?: any // TODO: add documentation of this property or change any
   className?: string
   style?: CSSProperties
   theme?: ThemeTypes
@@ -174,6 +171,7 @@ const Dropdown: React.FC<DropdownProps> = observer(
               <>
                 {items.map((item, index) => (
                   <DropdownItem
+                    key={`dropdown-item-${index}`}
                     theme={theme}
                     highlighted={highlightedIndex === index}
                     {...getItemProps({

--- a/src/common/input/Dropdown.tsx
+++ b/src/common/input/Dropdown.tsx
@@ -83,10 +83,10 @@ const DropdownItem = styled.li<{ highlighted: boolean }>`
 export type DropdownProps = {
   disabled?: boolean
   label?: string
-  items: any[] // any object (remember to pass itemToString, itemToLabel), array, { field, value } object
+  items: any[] // any object (remember to pass itemToString, itemToLabel), array, { field, value } object.
   onSelect: (selectedItem: any | null) => unknown
-  itemToString?: string | ((item: any | null) => string) // property of given object to get value from
-  itemToLabel?: string | ((item: any | null) => string) // property of given object to get label from
+  itemToString?: string | ((item: any | null) => string) // property of given object to get value from or a function that returns the value.
+  itemToLabel?: string | ((item: any | null) => string) // property of given object to get label from or a function that returns the label.
   selectedItem?: any // TODO: add documentation of this property or change any
   className?: string
   style?: CSSProperties

--- a/src/common/input/SelectDate.tsx
+++ b/src/common/input/SelectDate.tsx
@@ -3,10 +3,10 @@ import { observer } from 'mobx-react-lite'
 import { AnyFunction } from '../../type/common'
 import Input from './Input'
 import styled from 'styled-components'
-import { DATE_FORMAT } from '../../constants'
-import { format, isAfter, isBefore, isValid, parseISO } from 'date-fns'
+import { isAfter, isBefore, isValid, parseISO } from 'date-fns'
 import { isEmpty } from 'lodash'
 import { useStateValue } from '../../state/useAppState'
+import { getDateString } from '../../util/formatDate'
 
 const InputWrapper = styled.div`
   position: relative;
@@ -85,7 +85,7 @@ const SelectDate: React.FC<PropTypes> = observer(
       }
 
       let validInput = getValidDate(inputValue)
-      return validInput ? format(validInput, DATE_FORMAT) : value
+      return validInput ? getDateString(validInput) : value
     }, [inputValue, value, getValidDate])
 
     // Update the local input state when then value from props changes
@@ -94,7 +94,7 @@ const SelectDate: React.FC<PropTypes> = observer(
         let validDate = getValidDate(value)
 
         if (validDate) {
-          setInputValue(format(validDate, DATE_FORMAT))
+          setInputValue(getDateString(validDate))
         }
       }
     }, [value])
@@ -113,7 +113,7 @@ const SelectDate: React.FC<PropTypes> = observer(
           `Could not convert inputValue as a valid Date object. Given inputValue: ${inputValue}`
         )
       } else {
-        let onChangeValue = isEmpty(inputValue) ? '' : format(validDate!, DATE_FORMAT)
+        let onChangeValue = isEmpty(inputValue) ? '' : getDateString(validDate!)
         onChange(onChangeValue)
       }
     }, [inputValue])

--- a/src/common/input/SelectOperator.tsx
+++ b/src/common/input/SelectOperator.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useCallback, useEffect, useMemo } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useQueryData } from '../../util/useQueryData'
 import { Operator, User, UserRole } from '../../schema-types'
-import Dropdown, { DropdownItem } from './Dropdown'
+import Dropdown from './Dropdown'
 import { gql } from '@apollo/client'
 import { compact } from 'lodash'
 import { useStateValue } from '../../state/useAppState'
@@ -107,17 +107,14 @@ const SelectOperator: React.FC<PropTypes> = observer(
     }, [userIsOperator, value, operators, onSelect, selectInitialId])
 
     const onSelectOperator = useCallback(
-      (selectedItem: DropdownItem) => {
-        let selectValue: Operator | null = null
-        let selectedOperator = operators.find(
-          (operator) => operator.id === selectedItem.value
-        )!
+      (selectedItem) => {
+        let selectValue = selectedItem
 
-        if (operatorIsValid(selectedOperator)) {
-          onSelect(selectedOperator)
-        } else {
-          onSelect(null)
+        if (!selectedItem || !operatorIsValid(selectedItem)) {
+          selectValue = null
         }
+
+        onSelect(selectValue)
       },
       [onSelect]
     )
@@ -128,19 +125,6 @@ const SelectOperator: React.FC<PropTypes> = observer(
       return !valueId ? null : operators.find((op) => valueId === op.id) || operators[0]
     }, [operators, value])
 
-    let getDropdownItem = (operator: Operator): DropdownItem => {
-      return {
-        label: operator.operatorName,
-        value: operator.id,
-      }
-    }
-    let dropdownItems: DropdownItem[] = operators.map((operator: Operator) =>
-      getDropdownItem(operator)
-    )
-    let selectedItem: DropdownItem | null = currentOperator
-      ? getDropdownItem(currentOperator)
-      : null
-
     return (
       <Dropdown
         disabled={disabled || operators.length < 2}
@@ -148,9 +132,11 @@ const SelectOperator: React.FC<PropTypes> = observer(
         style={style}
         theme={theme}
         label={label || undefined}
-        items={dropdownItems}
+        items={operators}
         onSelect={onSelectOperator}
-        selectedItem={selectedItem}
+        selectedItem={currentOperator}
+        itemToString="id"
+        itemToLabel="operatorName"
       />
     )
   }

--- a/src/common/input/SelectOperator.tsx
+++ b/src/common/input/SelectOperator.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useCallback, useEffect, useMemo } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useQueryData } from '../../util/useQueryData'
 import { Operator, User, UserRole } from '../../schema-types'
-import Dropdown from './Dropdown'
+import Dropdown, { DropdownItem } from './Dropdown'
 import { gql } from '@apollo/client'
 import { compact } from 'lodash'
 import { useStateValue } from '../../state/useAppState'
@@ -107,14 +107,17 @@ const SelectOperator: React.FC<PropTypes> = observer(
     }, [userIsOperator, value, operators, onSelect, selectInitialId])
 
     const onSelectOperator = useCallback(
-      (selectedItem) => {
-        let selectValue = selectedItem
+      (selectedItem: DropdownItem) => {
+        let selectValue: Operator | null = null
+        let selectedOperator = operators.find(
+          (operator) => operator.id === selectedItem.value
+        )!
 
-        if (!selectedItem || !operatorIsValid(selectedItem)) {
-          selectValue = null
+        if (operatorIsValid(selectedOperator)) {
+          onSelect(selectedOperator)
+        } else {
+          onSelect(null)
         }
-
-        onSelect(selectValue)
       },
       [onSelect]
     )
@@ -125,6 +128,19 @@ const SelectOperator: React.FC<PropTypes> = observer(
       return !valueId ? null : operators.find((op) => valueId === op.id) || operators[0]
     }, [operators, value])
 
+    let getDropdownItem = (operator: Operator): DropdownItem => {
+      return {
+        label: operator.operatorName,
+        value: operator.id,
+      }
+    }
+    let dropdownItems: DropdownItem[] = operators.map((operator: Operator) =>
+      getDropdownItem(operator)
+    )
+    let selectedItem: DropdownItem | null = currentOperator
+      ? getDropdownItem(currentOperator)
+      : null
+
     return (
       <Dropdown
         disabled={disabled || operators.length < 2}
@@ -132,11 +148,9 @@ const SelectOperator: React.FC<PropTypes> = observer(
         style={style}
         theme={theme}
         label={label || undefined}
-        items={operators}
+        items={dropdownItems}
         onSelect={onSelectOperator}
-        selectedItem={currentOperator}
-        itemToString="id"
-        itemToLabel="operatorName"
+        selectedItem={selectedItem}
       />
     )
   }

--- a/src/contract/ContractListItem.tsx
+++ b/src/contract/ContractListItem.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
 import { Contract } from '../schema-types'
 import ExpandableSection, { HeaderSection } from '../common/components/ExpandableSection'
-import { format, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../constants'
+import { getReadableDateRange } from '../util/formatDate'
 
 const ContractTitle = styled.h3`
   margin: 0;
@@ -33,8 +32,10 @@ const ContractListItem: React.FC<PropTypes> = observer(
               <HeaderSection>{contractData?.description}</HeaderSection>
             )}
             <HeaderSection>
-              {format(parseISO(contractData?.startDate), READABLE_DATE_FORMAT)} -{' '}
-              {format(parseISO(contractData?.endDate), READABLE_DATE_FORMAT)}
+              {getReadableDateRange({
+                start: contractData?.startDate,
+                end: contractData?.endDate,
+              })}
             </HeaderSection>
             {headerContent}
           </>

--- a/src/dev/PreInspectionDevTools.tsx
+++ b/src/dev/PreInspectionDevTools.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
 import { Button } from '../common/components/Button'
 import { gql } from '@apollo/client'
-import { DEBUG } from '../constants'
 import { useMutationData } from '../util/useMutationData'
 import { Inspection } from '../schema-types'
 

--- a/src/executionRequirement/PostInspectionExecutionRequirements.tsx
+++ b/src/executionRequirement/PostInspectionExecutionRequirements.tsx
@@ -24,7 +24,7 @@ import {
   updateObservedExecutionRequirementValuesMutation,
 } from './executionRequirementsQueries'
 import { groupBy, toString } from 'lodash'
-import { readableDateRange } from '../util/formatDate'
+import { getReadableDateRange } from '../util/formatDate'
 import { FlexRow } from '../common/components/common'
 import { round } from '../util/round'
 import { getTotal } from '../util/getTotal'
@@ -190,7 +190,7 @@ const PostInspectionExecutionRequirements = observer(({ isEditable }: PropTypes)
         areaName,
         Object.entries<ObservedExecutionRequirement[]>(
           groupBy<ObservedExecutionRequirement>(areaReqs, (req) =>
-            readableDateRange({ start: req.startDate, end: req.endDate })
+            getReadableDateRange({ start: req.startDate, end: req.endDate })
           )
         ),
       ]),

--- a/src/executionRequirement/PostInspectionExecutionRequirements.tsx
+++ b/src/executionRequirement/PostInspectionExecutionRequirements.tsx
@@ -180,9 +180,10 @@ const PostInspectionExecutionRequirements = observer(({ isEditable }: PropTypes)
     }
   }, [inspection, removeRequirements, observedRequirements, isEditable])
 
-  let requirementsByAreaAndWeek: Array<
-    [string, Array<[string, ObservedExecutionRequirement[]]>]
-  > = useMemo(
+  let requirementsByAreaAndWeek: Array<[
+    string,
+    Array<[string, ObservedExecutionRequirement[]]>
+  ]> = useMemo(
     () =>
       Object.entries<ObservedExecutionRequirement[]>(
         groupBy<ObservedExecutionRequirement>(observedRequirements, 'area.name')
@@ -190,7 +191,7 @@ const PostInspectionExecutionRequirements = observer(({ isEditable }: PropTypes)
         areaName,
         Object.entries<ObservedExecutionRequirement[]>(
           groupBy<ObservedExecutionRequirement>(areaReqs, (req) =>
-            readableDateRange(req.startDate, req.endDate)
+            readableDateRange({ startDate: req.startDate, endDate: req.endDate })
           )
         ),
       ]),

--- a/src/executionRequirement/PostInspectionExecutionRequirements.tsx
+++ b/src/executionRequirement/PostInspectionExecutionRequirements.tsx
@@ -180,10 +180,9 @@ const PostInspectionExecutionRequirements = observer(({ isEditable }: PropTypes)
     }
   }, [inspection, removeRequirements, observedRequirements, isEditable])
 
-  let requirementsByAreaAndWeek: Array<[
-    string,
-    Array<[string, ObservedExecutionRequirement[]]>
-  ]> = useMemo(
+  let requirementsByAreaAndWeek: Array<
+    [string, Array<[string, ObservedExecutionRequirement[]]>]
+  > = useMemo(
     () =>
       Object.entries<ObservedExecutionRequirement[]>(
         groupBy<ObservedExecutionRequirement>(observedRequirements, 'area.name')
@@ -191,7 +190,7 @@ const PostInspectionExecutionRequirements = observer(({ isEditable }: PropTypes)
         areaName,
         Object.entries<ObservedExecutionRequirement[]>(
           groupBy<ObservedExecutionRequirement>(areaReqs, (req) =>
-            readableDateRange({ startDate: req.startDate, endDate: req.endDate })
+            readableDateRange({ start: req.startDate, end: req.endDate })
           )
         ),
       ]),

--- a/src/inspection/InspectionApprovalSubmit.tsx
+++ b/src/inspection/InspectionApprovalSubmit.tsx
@@ -7,8 +7,8 @@ import { FlexRow } from '../common/components/common'
 import { Button, ButtonStyle } from '../common/components/Button'
 import { ActionsWrapper } from '../common/input/ItemForm'
 import styled from 'styled-components'
-import { addDays, format, max, parseISO } from 'date-fns'
-import { DATE_FORMAT } from '../constants'
+import { addDays, max, parseISO } from 'date-fns'
+import { getDateString } from '../util/formatDate'
 import { LoadingDisplay } from '../common/components/Loading'
 
 const InspectionConfigView = styled.div`
@@ -51,8 +51,8 @@ const InspectionApprovalSubmit: React.FC<PropTypes> = observer(
       endDate = max([addDays(startDate, 1), endDate])
 
       return {
-        startDate: format(startDate, DATE_FORMAT),
-        endDate: format(endDate, DATE_FORMAT),
+        startDate: getDateString(startDate),
+        endDate: getDateString(endDate),
       }
     }, [])
 
@@ -96,9 +96,8 @@ const InspectionApprovalSubmit: React.FC<PropTypes> = observer(
               <SelectDate
                 name="production_start"
                 value={inspectionValues.endDate}
-                minDate={format(
-                  addDays(parseISO(inspection.startDate || inspection.minStartDate), 1),
-                  DATE_FORMAT
+                minDate={getDateString(
+                  addDays(parseISO(inspection.startDate || inspection.minStartDate), 1)
                 )}
                 maxDate={inspection.season.endDate}
                 onChange={(val) => onUpdateValue('startDate', val)}

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -36,9 +36,10 @@ const InspectionConfig: React.FC<PropTypes> = observer(
 
     let initialInspectionInputValues = getInspectionInputValues(inspection)
 
-    let [pendingInspectionInputValues, setPendingInspectionInputValues] = useState<
-      InspectionInput
-    >(initialInspectionInputValues)
+    let [
+      pendingInspectionInputValues,
+      setPendingInspectionInputValues,
+    ] = useState<InspectionInput>(initialInspectionInputValues)
 
     let onUpdateValue = useCallback((name: string, value: any) => {
       setPendingInspectionInputValues((currentValues) => {

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -13,6 +13,7 @@ import { DATE_FORMAT } from '../constants'
 import styled from 'styled-components'
 import { format, parseISO, startOfISOWeek } from 'date-fns'
 import InspectionTimeline from './InspectionTimeline'
+import InspectionSelectDates from './inspectionSelectDates'
 
 const InspectionConfigView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -41,7 +42,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(
       InspectionInput
     >(initialInspectionInputValues)
 
-    let onUpdateValue = useCallback((name, value) => {
+    let onUpdateValue = useCallback((name: string, value: any) => {
       setPendingInspectionInputValues((currentValues) => {
         let nextValues: InspectionInput = { ...currentValues }
         nextValues[name] = value
@@ -75,13 +76,21 @@ const InspectionConfig: React.FC<PropTypes> = observer(
               <FormColumn>
                 <Input
                   value={pendingInspectionInputValues.name || ''}
-                  onChange={(val) => onUpdateValue('name', val)}
                   label="Tarkastuksen nimi"
                 />
               </FormColumn>
             </FlexRow>
             <FlexRow>
               <InspectionTimeline currentInspection={inspection} />
+            </FlexRow>
+            <FlexRow>
+              <InspectionSelectDates
+                inspection={inspection}
+                onChange={(startDate: Date, endDate: Date) => {
+                  onUpdateValue('inspectionStartDate', startDate)
+                  onUpdateValue('inspectionEndDate', endDate)
+                }}
+              />
             </FlexRow>
             <FlexRow>
               {inspection.status !== InspectionStatus.Draft && (

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -11,7 +11,7 @@ import { ActionsWrapper } from '../common/input/ItemForm'
 import styled from 'styled-components'
 import InspectionTimeline from './InspectionTimeline'
 import InspectionSelectDates from './inspectionSelectDates'
-import { getBulttiDate } from '../util/formatDate'
+import { getDateString } from '../util/formatDate'
 import { Text, text } from '../util/translate'
 
 const InspectionConfigView = styled(PageSection)`
@@ -93,8 +93,8 @@ const InspectionConfig: React.FC<PropTypes> = observer(
                 inspectionType={inspection.inspectionType}
                 inspectionInput={pendingInspectionInputValues}
                 onChange={(startDate: Date, endDate: Date) => {
-                  onUpdateValue('inspectionStartDate', getBulttiDate(startDate))
-                  onUpdateValue('inspectionEndDate', getBulttiDate(endDate))
+                  onUpdateValue('inspectionStartDate', getDateString(startDate))
+                  onUpdateValue('inspectionEndDate', getDateString(endDate))
                 }}
               />
             </FlexRow>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 import InspectionTimeline from './InspectionTimeline'
 import InspectionSelectDates from './inspectionSelectDates'
 import { getBulttiDate } from '../util/formatDate'
+import { Text, text } from '../util/translate'
 
 const InspectionConfigView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -67,7 +68,9 @@ const InspectionConfig: React.FC<PropTypes> = observer(
       <InspectionConfigView>
         {!inspection ? (
           <MessageContainer>
-            <MessageView>Tarkastusta ei ole valittu.</MessageView>
+            <MessageView>
+              <Text>inspection.inspection_not_selected</Text>
+            </MessageView>
           </MessageContainer>
         ) : (
           <>
@@ -75,7 +78,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(
               <FormColumn>
                 <Input
                   value={pendingInspectionInputValues.name || ''}
-                  label="Tarkastuksen nimi"
+                  label={text('inspection.inspection_name')}
                   onChange={(value: string) => {
                     onUpdateValue('name', value)
                   }}
@@ -98,19 +101,19 @@ const InspectionConfig: React.FC<PropTypes> = observer(
             <FlexRow>
               {inspection.status !== InspectionStatus.Draft && (
                 <FormColumn>
-                  <InputLabel theme="light">Tuotantojakso</InputLabel>
+                  <InputLabel theme="light">{text('inspection.inspection_season')}</InputLabel>
                   <ControlGroup>
                     <Input
                       type="date"
                       value={inspection.startDate}
-                      label="Alku"
+                      label={text('start_date')}
                       subLabel={true}
                       disabled={true}
                     />
                     <Input
                       type="date"
                       value={inspection.endDate}
-                      label="Loppu"
+                      label={text('end_date')}
                       subLabel={true}
                       disabled={true}
                     />
@@ -121,14 +124,14 @@ const InspectionConfig: React.FC<PropTypes> = observer(
             <FlexRow>
               <ActionsWrapper>
                 <Button style={{ marginRight: '1rem' }} onClick={onSave} disabled={!isDirty}>
-                  Tallenna
+                  <Text>general.app.save</Text>
                 </Button>
                 <Button
                   buttonStyle={ButtonStyle.SECONDARY_REMOVE}
                   onClick={() =>
                     setPendingInspectionInputValues(getInspectionInputValues(inspection))
                   }>
-                  Peruuta
+                  <Text>general.app.cancel</Text>
                 </Button>
               </ActionsWrapper>
             </FlexRow>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import SelectDate from '../common/input/SelectDate'
 import Input from '../common/input/Input'
 import { isEqual, pick } from 'lodash'
 import { ControlGroup, FormColumn, InputLabel } from '../common/components/form'
@@ -9,9 +8,7 @@ import { MessageContainer, MessageView } from '../common/components/Messages'
 import { FlexRow, PageSection } from '../common/components/common'
 import { Button, ButtonStyle } from '../common/components/Button'
 import { ActionsWrapper } from '../common/input/ItemForm'
-import { DATE_FORMAT } from '../constants'
 import styled from 'styled-components'
-import { format, parseISO, startOfISOWeek } from 'date-fns'
 import InspectionTimeline from './InspectionTimeline'
 import InspectionSelectDates from './inspectionSelectDates'
 import { getBulttiDate } from '../util/formatDate'
@@ -78,6 +75,9 @@ const InspectionConfig: React.FC<PropTypes> = observer(
                 <Input
                   value={pendingInspectionInputValues.name || ''}
                   label="Tarkastuksen nimi"
+                  onChange={(value: string) => {
+                    onUpdateValue('name', value)
+                  }}
                 />
               </FormColumn>
             </FlexRow>
@@ -86,6 +86,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(
             </FlexRow>
             <FlexRow>
               <InspectionSelectDates
+                inspectionType={inspection.inspectionType}
                 inspectionInput={pendingInspectionInputValues}
                 onChange={(startDate: Date, endDate: Date) => {
                   onUpdateValue('inspectionStartDate', getBulttiDate(startDate))
@@ -115,31 +116,6 @@ const InspectionConfig: React.FC<PropTypes> = observer(
                   </ControlGroup>
                 </FormColumn>
               )}
-              <FormColumn>
-                <InputLabel theme="light">Tarkastusjakso</InputLabel>
-                <ControlGroup>
-                  <SelectDate
-                    name="inspection_start"
-                    minDate={format(
-                      startOfISOWeek(parseISO(inspection.minStartDate)),
-                      DATE_FORMAT
-                    )}
-                    value={pendingInspectionInputValues.inspectionStartDate}
-                    onChange={(val) => onUpdateValue('inspectionStartDate', val)}
-                    label="Alku"
-                    disabled={!isEditable}
-                  />
-                  <SelectDate
-                    name="inspection_end"
-                    value={pendingInspectionInputValues.inspectionEndDate}
-                    minDate={inspection.inspectionStartDate}
-                    onChange={(val) => onUpdateValue('inspectionEndDate', val)}
-                    label="Loppu"
-                    disabled={!isEditable}
-                    alignDatepicker="right"
-                  />
-                </ControlGroup>
-              </FormColumn>
             </FlexRow>
             <FlexRow>
               <ActionsWrapper>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components'
 import { format, parseISO, startOfISOWeek } from 'date-fns'
 import InspectionTimeline from './InspectionTimeline'
 import InspectionSelectDates from './inspectionSelectDates'
+import { getBulttiDate } from '../util/formatDate'
 
 const InspectionConfigView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -85,10 +86,10 @@ const InspectionConfig: React.FC<PropTypes> = observer(
             </FlexRow>
             <FlexRow>
               <InspectionSelectDates
-                inspection={inspection}
+                inspectionInput={pendingInspectionInputValues}
                 onChange={(startDate: Date, endDate: Date) => {
-                  onUpdateValue('inspectionStartDate', startDate)
-                  onUpdateValue('inspectionEndDate', endDate)
+                  onUpdateValue('inspectionStartDate', getBulttiDate(startDate))
+                  onUpdateValue('inspectionEndDate', getBulttiDate(endDate))
                 }}
               />
             </FlexRow>

--- a/src/inspection/InspectionItem.tsx
+++ b/src/inspection/InspectionItem.tsx
@@ -5,9 +5,8 @@ import { getCreatedBy } from './inspectionUtils'
 import ValueDisplay, {
   PropTypes as ValueDisplayPropTypes,
 } from '../common/components/ValueDisplay'
-import { format, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT, READABLE_TIME_FORMAT } from '../constants'
 import InspectionActions from './InspectionActions'
+import { getReadableDate } from '../util/formatDate'
 
 const InspectionItemView = styled.div<{ status?: InspectionStatus; inEffect?: boolean }>`
   padding: 0.75rem 0.75rem 0;
@@ -72,12 +71,12 @@ const renderValue = (key, val) => {
   switch (key) {
     case 'createdAt':
     case 'updatedAt':
-      return format(parseISO(val), READABLE_TIME_FORMAT)
+      return getReadableDate(val)
     case 'startDate':
     case 'inspectionStartDate':
     case 'endDate':
     case 'inspectionEndDate':
-      return format(parseISO(val), READABLE_DATE_FORMAT)
+      return getReadableDate(val)
     case 'status':
       if (val === InspectionStatus.InProduction) {
         return 'Tuotannossa'

--- a/src/inspection/InspectionTimeline.tsx
+++ b/src/inspection/InspectionTimeline.tsx
@@ -6,11 +6,10 @@ import { Inspection, InspectionStatus, InspectionTimelineItem } from '../schema-
 import DateRangeDisplay from '../common/components/DateRangeDisplay'
 import { InputLabel } from '../common/components/form'
 import { ArrowRight } from '../common/icon/ArrowRight'
-import { format, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../constants'
 import { orderBy } from 'lodash'
 import { useQueryData } from '../util/useQueryData'
 import { inspectionsTimelineByOperatorQuery } from './inspectionQueries'
+import { getReadableDate } from '../util/formatDate'
 
 const InspectionTimelineView = styled.div`
   margin: 1rem 0;
@@ -96,7 +95,7 @@ const InspectionTimeline = observer(({ currentInspection }: PropTypes) => {
         <TimelineStart>
           Kauden alku
           <br />
-          <strong>{format(parseISO(season.startDate), READABLE_DATE_FORMAT)}</strong>
+          <strong>{getReadableDate(season.startDate)}</strong>
         </TimelineStart>
         {arrow}
       </>

--- a/src/inspection/InspectionsList.tsx
+++ b/src/inspection/InspectionsList.tsx
@@ -10,12 +10,11 @@ import {
 } from './inspectionUtils'
 import { useStateValue } from '../state/useAppState'
 import { Button } from '../common/components/Button'
-import { DATE_FORMAT } from '../constants'
-import { format } from 'date-fns'
 import { isBetween } from '../util/isBetween'
 import { LoadingDisplay } from '../common/components/Loading'
 import { useSeasons } from '../util/useSeasons'
 import { MessageView } from '../common/components/Messages'
+import { getDateString } from '../util/formatDate'
 
 const InspectionsListView = styled.div`
   min-height: 100%;
@@ -136,7 +135,7 @@ export type PropTypes = {
   onUpdate: () => unknown
 }
 
-let currentDate = format(new Date(), DATE_FORMAT)
+let currentDateString = getDateString(new Date())
 
 const InspectionsList: React.FC<PropTypes> = ({
   inspections,
@@ -175,7 +174,7 @@ const InspectionsList: React.FC<PropTypes> = ({
   let currentSeason = useMemo(
     () =>
       seasons.reduce((curSeason: Season | null, season: Season) => {
-        if (!curSeason && isBetween(currentDate, season.startDate, season.endDate)) {
+        if (!curSeason && isBetween(currentDateString, season.startDate, season.endDate)) {
           return season
         }
 
@@ -228,7 +227,7 @@ const InspectionsList: React.FC<PropTypes> = ({
               {inspections.map((inspection) => {
                 let renderCurrentTemporalLocation =
                   currentSeason?.id === seasonId &&
-                  isBetween(currentDate, inspection.startDate, inspection.endDate)
+                  isBetween(currentDateString, inspection.startDate, inspection.endDate)
 
                 return (
                   <React.Fragment

--- a/src/inspection/SelectInspection.tsx
+++ b/src/inspection/SelectInspection.tsx
@@ -10,13 +10,12 @@ import {
   useCreateInspection,
   useEditInspection,
 } from './inspectionUtils'
-import { format, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../constants'
 import { MessageContainer, MessageView } from '../common/components/Messages'
 import { SubHeading } from '../common/components/Typography'
 import InspectionActions from './InspectionActions'
 import { Plus } from '../common/icon/Plus'
 import { LoadingDisplay } from '../common/components/Loading'
+import { getReadableDate } from '../util/formatDate'
 
 const SelectInspectionView = styled.div`
   position: relative;
@@ -261,24 +260,13 @@ const SelectInspection: React.FC<PropTypes> = observer(
                     </InspectionStatusDisplay>
                     <InspectionPeriodDisplay>
                       <DateTitle>Tuotantojakso</DateTitle>
-                      <StartDate>
-                        {format(parseISO(inspection.startDate), READABLE_DATE_FORMAT)}
-                      </StartDate>
-                      <EndDate>
-                        {format(parseISO(inspection.endDate), READABLE_DATE_FORMAT)}
-                      </EndDate>
+                      <StartDate>{getReadableDate(inspection.startDate)}</StartDate>
+                      <EndDate>{getReadableDate(inspection.endDate)}</EndDate>
                     </InspectionPeriodDisplay>
                     <InspectionPeriodDisplay>
                       <DateTitle>Tarkastusjakso</DateTitle>
-                      <StartDate>
-                        {format(
-                          parseISO(inspection.inspectionStartDate),
-                          READABLE_DATE_FORMAT
-                        )}
-                      </StartDate>
-                      <EndDate>
-                        {format(parseISO(inspection.inspectionEndDate), READABLE_DATE_FORMAT)}
-                      </EndDate>
+                      <StartDate>{getReadableDate(inspection.inspectionStartDate)}</StartDate>
+                      <EndDate>{getReadableDate(inspection.inspectionEndDate)}</EndDate>
                     </InspectionPeriodDisplay>
                   </ItemContent>
                   <InspectionActions onRefresh={refetchInspections} inspection={inspection} />

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -63,8 +63,8 @@ const InspectionSelectDates = observer(
       inspectionInput.inspectionStartDate && inspectionInput.inspectionEndDate
         ? {
             label: readableDateRange({
-              startDate: inspectionInput.inspectionStartDate,
-              endDate: inspectionInput.inspectionEndDate,
+              start: inspectionInput.inspectionStartDate,
+              end: inspectionInput.inspectionEndDate,
             }),
             value: {
               startDate: inspectionInput.inspectionStartDate,
@@ -104,7 +104,7 @@ const _getPreInspectionDateOptions = (): DateOption[] => {
       startDate,
       endDate,
     }
-    let label = readableDateRange({ startDate, endDate })
+    let label = readableDateRange({ start: startDate, end: endDate })
     return {
       label,
       value,
@@ -126,7 +126,7 @@ const _getPostInspectionDateOptions = (
     .filter(isInspectionDateValid)
     .map((inspectionDate: InspectionDate) => {
       let { startDate, endDate } = inspectionDate
-      let label = readableDateRange({ startDate, endDate })
+      let label = readableDateRange({ start: startDate, end: endDate })
       return {
         label,
         value: {

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite'
 import { eachWeekOfInterval, parseISO, startOfWeek, subMonths, isBefore } from 'date-fns'
 import { InspectionDate, InspectionInput, InspectionType } from '../schema-types'
 import Dropdown from '../common/input/Dropdown'
-import { getDateObject, readableDateRange } from '../util/formatDate'
+import { getDateObject, getReadableDateRange } from '../util/formatDate'
 import { useLazyQueryData } from '../util/useLazyQueryData'
 import { allInspectionDatesQuery } from './inspectionDate/inspectionDateQuery'
 import { LoadingDisplay } from '../common/components/Loading'
@@ -62,7 +62,7 @@ const InspectionSelectDates = observer(
     let selectedItem: DateOption | null =
       inspectionInput.inspectionStartDate && inspectionInput.inspectionEndDate
         ? {
-            label: readableDateRange({
+            label: getReadableDateRange({
               start: inspectionInput.inspectionStartDate,
               end: inspectionInput.inspectionEndDate,
             }),
@@ -104,7 +104,7 @@ function _getPreInspectionDateOptions(): DateOption[] {
       startDate,
       endDate,
     }
-    let label = readableDateRange({ start: startDate, end: endDate })
+    let label = getReadableDateRange({ start: startDate, end: endDate })
     return {
       label,
       value,
@@ -126,7 +126,7 @@ function _getPostInspectionDateOptions(
     .filter(isInspectionDateValid)
     .map((inspectionDate: InspectionDate) => {
       let { startDate, endDate } = inspectionDate
-      let label = readableDateRange({ start: startDate, end: endDate })
+      let label = getReadableDateRange({ start: startDate, end: endDate })
       return {
         label,
         value: {

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -44,10 +44,10 @@ const InspectionSelectDates = observer(
 
     let dateOptions: DateOption[] = []
     if (inspectionType === InspectionType.Pre) {
-      dateOptions = _getPreInspectionDateOptions()
+      dateOptions = getPreInspectionDateOptions()
     } else {
       if (inspectionDatesQueryResult) {
-        dateOptions = _getPostInspectionDateOptions(inspectionDatesQueryResult)
+        dateOptions = getPostInspectionDateOptions(inspectionDatesQueryResult)
       } else {
         _queryPostinspectionDateOptions()
       }
@@ -89,7 +89,7 @@ const InspectionSelectDates = observer(
   }
 )
 
-function _getPreInspectionDateOptions(): DateOption[] {
+function getPreInspectionDateOptions(): DateOption[] {
   let startDate = new Date()
   let endDate = new Date(startDate)
   endDate.setDate(endDate.getDate() + 90)
@@ -113,7 +113,7 @@ function _getPreInspectionDateOptions(): DateOption[] {
   return dateOptions
 }
 
-function _getPostInspectionDateOptions(
+function getPostInspectionDateOptions(
   inspectionDatesQueryResult: InspectionDate[]
 ): DateOption[] {
   let dateOneMonthAgo = subMonths(new Date(), 1)

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -2,24 +2,29 @@ import React from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
 import { eachWeekOfInterval, startOfWeek } from 'date-fns'
-import { Inspection } from '../schema-types'
+import { InspectionInput } from '../schema-types'
 import Dropdown from '../common/input/Dropdown'
+import { readableDateRange } from '../util/formatDate'
 
 const InspectionSelectDatesView = styled.div`
   margin: 1rem 0;
+  width: 50%;
 `
 
-interface IDateOption {
-  endDate: Date
-  startDate: Date
+interface DateOption {
+  label: string
+  value: {
+    startDate: Date
+    endDate: Date
+  }
 }
 
 export type PropTypes = {
-  inspection: Inspection
-  onChange: Function
+  inspectionInput: InspectionInput
+  onChange: (startDate: Date, endDate: Date) => void
 }
 
-const InspectionSelectDates = observer(({ inspection, onChange }: PropTypes) => {
+const InspectionSelectDates = observer(({ inspectionInput, onChange }: PropTypes) => {
   // TODO: use inspection.InspectionType to know how to get options
   // preInspections: automatically generated options
   // postInspections: query options from backend
@@ -32,23 +37,41 @@ const InspectionSelectDates = observer(({ inspection, onChange }: PropTypes) => 
     end: endDate,
   })
 
-  let dateOptions: IDateOption[] = dateOptionsEndDates.map((endDate) => {
-    return {
+  let dateOptions: DateOption[] = dateOptionsEndDates.map((endDate) => {
+    const startDate = startOfWeek(endDate, { weekStartsOn: 1 })
+    const value = {
+      startDate,
       endDate,
-      startDate: startOfWeek(endDate, { weekStartsOn: 1 }),
+    }
+    const label = readableDateRange({ startDate, endDate })
+    return {
+      label,
+      value,
     }
   })
-  const onSelectDates = (val: any) => {
-    // TODO, call onChange
+  const onSelectDates = (dateOption: DateOption) => {
+    onChange(dateOption.value.startDate, dateOption.value.endDate)
   }
-
+  let selectedItem: DateOption | null =
+    inspectionInput.inspectionStartDate && inspectionInput.inspectionEndDate
+      ? {
+          label: readableDateRange({
+            startDate: inspectionInput.inspectionStartDate,
+            endDate: inspectionInput.inspectionEndDate,
+          }),
+          value: {
+            startDate: inspectionInput.inspectionStartDate,
+            endDate: inspectionInput.inspectionEndDate!,
+          },
+        }
+      : null
   return (
     <InspectionSelectDatesView>
       <Dropdown
-        label={'Valitse aika'}
+        label={'Valitse tarkastusjakso'}
         items={dateOptions}
         onSelect={onSelectDates}
-        selectedItem={''}
+        selectedItem={selectedItem}
       />
     </InspectionSelectDatesView>
   )

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -89,7 +89,7 @@ const InspectionSelectDates = observer(
   }
 )
 
-const _getPreInspectionDateOptions = (): DateOption[] => {
+function _getPreInspectionDateOptions(): DateOption[] {
   let startDate = new Date()
   let endDate = new Date(startDate)
   endDate.setDate(endDate.getDate() + 90)
@@ -113,9 +113,9 @@ const _getPreInspectionDateOptions = (): DateOption[] => {
   return dateOptions
 }
 
-const _getPostInspectionDateOptions = (
+function _getPostInspectionDateOptions(
   inspectionDatesQueryResult: InspectionDate[]
-): DateOption[] => {
+): DateOption[] {
   let dateOneMonthAgo = sub(new Date(), { months: 1 })
   const isInspectionDateValid = (inspectionDate: InspectionDate) => {
     // Only dates that are older than 1 month are valid

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -8,6 +8,7 @@ import { getDateObject, readableDateRange } from '../util/formatDate'
 import { useLazyQueryData } from '../util/useLazyQueryData'
 import { allInspectionDatesQuery } from './inspectionDate/inspectionDateQuery'
 import { LoadingDisplay } from '../common/components/Loading'
+import { text } from '../util/translate'
 
 const InspectionSelectDatesView = styled.div`
   margin: 1rem 0;
@@ -77,7 +78,7 @@ const InspectionSelectDates = observer(
           <LoadingDisplay />
         ) : (
           <Dropdown
-            label={'Valitse tarkastusjakso'}
+            label={text('inspection.select_inspection')}
             items={dateOptions}
             onSelect={onSelectDates}
             selectedItem={selectedItem}

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
-import { eachWeekOfInterval, parseISO, startOfWeek, sub, isBefore } from 'date-fns'
+import { eachWeekOfInterval, parseISO, startOfWeek, subMonths, isBefore } from 'date-fns'
 import { InspectionDate, InspectionInput, InspectionType } from '../schema-types'
 import Dropdown from '../common/input/Dropdown'
 import { getDateObject, readableDateRange } from '../util/formatDate'
@@ -116,7 +116,7 @@ function _getPreInspectionDateOptions(): DateOption[] {
 function _getPostInspectionDateOptions(
   inspectionDatesQueryResult: InspectionDate[]
 ): DateOption[] {
-  let dateOneMonthAgo = sub(new Date(), { months: 1 })
+  let dateOneMonthAgo = subMonths(new Date(), 1)
   const isInspectionDateValid = (inspectionDate: InspectionDate) => {
     // Only dates that are older than 1 month are valid
     return isBefore(getDateObject(inspectionDate.endDate), dateOneMonthAgo)

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import styled from 'styled-components'
+import { observer } from 'mobx-react-lite'
+import { eachWeekOfInterval, startOfWeek } from 'date-fns'
+import { Inspection } from '../schema-types'
+import Dropdown from '../common/input/Dropdown'
+
+const InspectionSelectDatesView = styled.div`
+  margin: 1rem 0;
+`
+
+interface IDateOption {
+  endDate: Date
+  startDate: Date
+}
+
+export type PropTypes = {
+  inspection: Inspection
+  onChange: Function
+}
+
+const InspectionSelectDates = observer(({ inspection, onChange }: PropTypes) => {
+  // TODO: use inspection.InspectionType to know how to get options
+  // preInspections: automatically generated options
+  // postInspections: query options from backend
+
+  let startDate = new Date()
+  let endDate = new Date(startDate)
+  endDate.setDate(endDate.getDate() + 90)
+  let dateOptionsEndDates = eachWeekOfInterval({
+    start: startDate,
+    end: endDate,
+  })
+
+  let dateOptions: IDateOption[] = dateOptionsEndDates.map((endDate) => {
+    return {
+      endDate,
+      startDate: startOfWeek(endDate, { weekStartsOn: 1 }),
+    }
+  })
+  const onSelectDates = (val: any) => {
+    // TODO, call onChange
+  }
+
+  return (
+    <InspectionSelectDatesView>
+      <Dropdown
+        label={'Valitse aika'}
+        items={dateOptions}
+        onSelect={onSelectDates}
+        selectedItem={''}
+      />
+    </InspectionSelectDatesView>
+  )
+})
+
+export default InspectionSelectDates

--- a/src/page/EditContractPage.tsx
+++ b/src/page/EditContractPage.tsx
@@ -7,14 +7,14 @@ import { contractQuery } from '../contract/contractQueries'
 import ContractEditor from '../contract/ContractEditor'
 import { Contract } from '../schema-types'
 import { useStateValue } from '../state/useAppState'
-import { DATE_FORMAT } from '../constants'
 import { useHasAdminAccessRights, useHasOperatorUserAccessRights } from '../util/userRoles'
-import { addYears, format } from 'date-fns'
+import { addYears } from 'date-fns'
 import { LoadingDisplay } from '../common/components/Loading'
 import { Page } from '../common/components/common'
 import { useRefetch } from '../util/useRefetch'
 import { PageTitle } from '../common/components/PageTitle'
 import { navigateWithQueryString } from '../util/urlValue'
+import { getDateString } from '../util/formatDate'
 
 const EditContractPageView = styled(Page)``
 
@@ -50,8 +50,8 @@ const EditContractPage = observer(({ contractId }: PropTypes) => {
       setNewContract({
         operatorId: operator?.id,
         operator,
-        startDate: format(new Date(), DATE_FORMAT),
-        endDate: format(addYears(new Date(), 1), DATE_FORMAT),
+        startDate: getDateString(new Date()),
+        endDate: getDateString(addYears(new Date(), 1)),
       })
     }
   }, [contractId, newContract, operator])

--- a/src/page/InspectionDatePage.tsx
+++ b/src/page/InspectionDatePage.tsx
@@ -12,6 +12,7 @@ import { useQueryData } from '../util/useQueryData'
 import { allInspectionDatesQuery } from '../inspection/inspectionDate/inspectionDateQuery'
 import { orderBy } from 'lodash'
 import { Text } from '../util/translate'
+import { InspectionDate } from '../schema-types'
 
 const InspectionDatesPage = styled.div`
   padding: 0 1rem 1rem 1rem;
@@ -31,7 +32,7 @@ const InspectionDatePage: React.FC<PropTypes> = observer(() => {
     data: inspectionDatesQueryResult,
     loading: areInspectionDatesLoading,
     refetch: refetchInspectionDates,
-  } = useQueryData(allInspectionDatesQuery)
+  } = useQueryData<InspectionDate[]>(allInspectionDatesQuery)
 
   let refetch = useRefetch(refetchInspectionDates)
 

--- a/src/page/InspectionReportIndexPage.tsx
+++ b/src/page/InspectionReportIndexPage.tsx
@@ -15,11 +15,10 @@ import { InspectionStatus, InspectionType, Season } from '../schema-types'
 import SelectSeason from '../common/input/SelectSeason'
 import { LoadingDisplay } from '../common/components/Loading'
 import Dropdown from '../common/input/Dropdown'
-import { format, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../constants'
 import { orderBy } from 'lodash'
 import { PageTitle } from '../common/components/PageTitle'
 import InspectionIndexItem from '../inspection/InspectionIndexItem'
+import { getReadableDate } from '../util/formatDate'
 
 const InspectionReportIndexPageView = styled(Page)``
 
@@ -102,7 +101,7 @@ const InspectionReportIndexPage: React.FC<PropTypes> = observer(({ inspectionTyp
       defaultSelectedDate,
       ...inspectionsList.map((p) => ({
         value: p.startDate,
-        label: format(parseISO(p.startDate), READABLE_DATE_FORMAT),
+        label: getReadableDate(p.startDate),
       })),
     ],
     [inspectionsList]

--- a/src/page/ProcurementUnitsPage.tsx
+++ b/src/page/ProcurementUnitsPage.tsx
@@ -7,8 +7,8 @@ import { useAppState } from '../state/useAppState'
 import ProcurementUnits from '../procurementUnit/ProcurementUnits'
 import { MessageContainer, MessageView } from '../common/components/Messages'
 import { PageTitle } from '../common/components/PageTitle'
-import { addDays, format, parseISO } from 'date-fns'
-import { DATE_FORMAT } from '../constants'
+import { addDays, parseISO } from 'date-fns'
+import { getDateString } from '../util/formatDate'
 
 const ProcurementUnitsView = styled(Page)``
 
@@ -38,7 +38,7 @@ const ProcurementUnitsPage: React.FC<PropTypes> = observer(() => {
             startDate={globalSeason?.startDate || ''}
             endDate={
               globalSeason?.startDate
-                ? format(addDays(parseISO(globalSeason.startDate), 7), DATE_FORMAT)
+                ? getDateString(addDays(parseISO(globalSeason.startDate), 7))
                 : ''
             }
           />

--- a/src/postInspection/LoadInspectionHfpData.tsx
+++ b/src/postInspection/LoadInspectionHfpData.tsx
@@ -12,7 +12,6 @@ import { flatten, orderBy, uniq, uniqBy } from 'lodash'
 import {
   addDays,
   eachDayOfInterval,
-  format,
   isSameDay,
   isWithinInterval,
   max,
@@ -21,10 +20,11 @@ import {
 } from 'date-fns'
 import { HfpDateStatus, HfpStatus, InspectionValidationError } from '../schema-types'
 import DateRangeDisplay from '../common/components/DateRangeDisplay'
-import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 import { pickGraphqlData } from '../util/pickGraphqlData'
 import { LoadingDisplay } from '../common/components/Loading'
 import { useHasInspectionError } from '../util/hasInspectionError'
+import { getReadableDate } from '../util/formatDate'
+import { getDateString } from '../util/formatDate'
 
 const LoadInspectionHfpDataView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -206,7 +206,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
     }
 
     let inspectionStatusGroup: HfpDateStatus[] = inspectionDates.map((date) => ({
-      date: format(date, DATE_FORMAT),
+      date: getDateString(date),
       status: HfpStatus.NotLoaded,
     }))
 
@@ -280,8 +280,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
       uniq(
         inspectionDates
           .map((date) => {
-            let dateStr = format(date, DATE_FORMAT)
-            return flatten(dateStatusByRanges).find((s) => s.date === dateStr)
+            return flatten(dateStatusByRanges).find((s) => s.date === getDateString(date))
           })
           .map((dateStatus) => dateStatus?.status || HfpStatus.NotLoaded)
       ),
@@ -377,7 +376,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
                 Nyt lataamassa
               </InputLabel>
               {inspectionDates.map((date) => {
-                let dateStr = format(date, 'yyyy-MM-dd')
+                let dateStr = getDateString(date)
                 let currentProgress = dateProgress.get(dateStr)
                 let loadedStatus = dateStatuses.find((status) => status.date === dateStr)
                   ?.status
@@ -396,7 +395,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
 
                 return (
                   <DateStatusDisplay key={`date progress ${dateStr}`}>
-                    <span>{format(date, READABLE_DATE_FORMAT)}</span>
+                    <span>{getReadableDate(date)}</span>
                     <DateProgressValue>{loadedProgress}%</DateProgressValue>
                   </DateStatusDisplay>
                 )

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -107,6 +107,10 @@
   "catalogue.equipment_not_found": "Kalustoa ei löydetty.",
   "catalogue.equipment.confirm_remove": "Haluatko varmasti poistaa ajoneuvon?",
 
+  "inspection.inspection_not_selected": "Tarkastusta ei ole valittu.",
+  "inspection.inspection_name": "Tarkastuksen nimi",
+  "inspection.select_inspection": "Valitse tarkastusjakso",
+  "inspection.inspection_season": "Tuotantojakso",
   "inspection.units.weekly_kilometers": "Kilometrejä viikossa",
   "inspection.units.area": "Seuranta-alue",
   "inspection.units.view_all": "Näytä kaikki kilpailukohteet",

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -15,12 +15,12 @@ export function getDateObject(date: AcceptedDateFormat): Date {
   return parseISO(date)
 }
 
-export function readableDate(date: AcceptedDateFormat): string {
+export function getReadableDate(date: AcceptedDateFormat): string {
   let dateObj = getDateObject(date)
   return format(dateObj, READABLE_DATE_FORMAT)
 }
 
-export function readableDateRange({
+export function getReadableDateRange({
   start,
   end,
 }: {
@@ -40,6 +40,6 @@ export function readableDateRange({
   )}`
 }
 
-export function getBulttiDate(date: Date): string {
-  return format(date, DATE_FORMAT)
+export function getDateString(date: AcceptedDateFormat): string {
+  return format(getDateObject(date), DATE_FORMAT)
 }

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -1,4 +1,4 @@
-import { format, fromUnixTime, isSameYear, parseISO } from 'date-fns'
+import { format, fromUnixTime, Interval, isSameYear, parseISO } from 'date-fns'
 import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 
 type AcceptedDateFormat = Date | string | number
@@ -20,15 +20,9 @@ export function getReadableDate(date: AcceptedDateFormat): string {
   return format(dateObj, READABLE_DATE_FORMAT)
 }
 
-export function getReadableDateRange({
-  start,
-  end,
-}: {
-  start: AcceptedDateFormat
-  end: AcceptedDateFormat
-}): string {
-  let startDateObj = getDateObject(start)
-  let endDateObj = getDateObject(end)
+export function getReadableDateRange(dateRange: Interval): string {
+  let startDateObj = getDateObject(dateRange.start)
+  let endDateObj = getDateObject(dateRange.end)
 
   // Unnecessary to show the year in the first date if both dates are from the same year
   let showYear = !isSameYear(startDateObj, endDateObj)

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -3,7 +3,7 @@ import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 
 type AcceptedDateFormat = Date | string | number
 
-function getDateObject(date: AcceptedDateFormat): Date {
+export function getDateObject(date: AcceptedDateFormat): Date {
   if (date instanceof Date) {
     return date
   }

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -1,4 +1,4 @@
-import { format, fromUnixTime, isSameYear, parseISO, Interval } from 'date-fns'
+import { format, fromUnixTime, isSameYear, parseISO } from 'date-fns'
 import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 
 type AcceptedDateFormat = Date | string | number

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -1,4 +1,4 @@
-import { format, fromUnixTime, isSameYear, parseISO } from 'date-fns'
+import { format, fromUnixTime, isSameYear, parseISO, Interval } from 'date-fns'
 import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 
 type AcceptedDateFormat = Date | string | number
@@ -21,14 +21,14 @@ export function readableDate(date: AcceptedDateFormat): string {
 }
 
 export function readableDateRange({
-  startDate,
-  endDate,
+  start,
+  end,
 }: {
-  startDate: AcceptedDateFormat
-  endDate: AcceptedDateFormat
+  start: AcceptedDateFormat
+  end: AcceptedDateFormat
 }): string {
-  let startDateObj = getDateObject(startDate)
-  let endDateObj = getDateObject(endDate)
+  let startDateObj = getDateObject(start)
+  let endDateObj = getDateObject(end)
 
   // Unnecessary to show the year in the first date if both dates are from the same year
   let showYear = !isSameYear(startDateObj, endDateObj)

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -1,9 +1,9 @@
 import { format, fromUnixTime, isSameYear, parseISO } from 'date-fns'
-import { READABLE_DATE_FORMAT } from '../constants'
+import { DATE_FORMAT, READABLE_DATE_FORMAT } from '../constants'
 
 type AcceptedDateFormat = Date | string | number
 
-function getDateObject(date: AcceptedDateFormat) {
+function getDateObject(date: AcceptedDateFormat): Date {
   if (date instanceof Date) {
     return date
   }
@@ -15,12 +15,18 @@ function getDateObject(date: AcceptedDateFormat) {
   return parseISO(date)
 }
 
-export function readableDate(date: AcceptedDateFormat) {
+export function readableDate(date: AcceptedDateFormat): string {
   let dateObj = getDateObject(date)
   return format(dateObj, READABLE_DATE_FORMAT)
 }
 
-export function readableDateRange(startDate: AcceptedDateFormat, endDate: AcceptedDateFormat) {
+export function readableDateRange({
+  startDate,
+  endDate,
+}: {
+  startDate: AcceptedDateFormat
+  endDate: AcceptedDateFormat
+}): string {
   let startDateObj = getDateObject(startDate)
   let endDateObj = getDateObject(endDate)
 
@@ -32,4 +38,8 @@ export function readableDateRange(startDate: AcceptedDateFormat, endDate: Accept
     endDateObj,
     READABLE_DATE_FORMAT
   )}`
+}
+
+export function getBulttiDate(date: Date): string {
+  return format(date, DATE_FORMAT)
 }

--- a/src/util/strval.ts
+++ b/src/util/strval.ts
@@ -1,6 +1,6 @@
 import { toString } from 'lodash'
-import { format, isValid } from 'date-fns'
-import { DATE_FORMAT } from '../constants'
+import { isValid } from 'date-fns'
+import { getDateString } from './formatDate'
 
 export const strval = (val: any): string => {
   if ((val !== 0 && !val) || (typeof val === 'number' && isNaN(val))) {
@@ -8,7 +8,7 @@ export const strval = (val: any): string => {
   }
 
   if (val instanceof Date && isValid(val)) {
-    return format(val, DATE_FORMAT)
+    return getDateString(val)
   }
 
   if (Array.isArray(val)) {

--- a/src/util/useSeasons.ts
+++ b/src/util/useSeasons.ts
@@ -1,8 +1,8 @@
 import { useQueryData } from './useQueryData'
 import { seasonsQuery } from '../common/query/seasonsQuery'
-import { format, startOfYear, subYears } from 'date-fns'
-import { DATE_FORMAT } from '../constants'
+import { startOfYear, subYears } from 'date-fns'
 import { Season } from '../schema-types'
+import { getDateString } from './formatDate'
 
 const currentDate = new Date()
 
@@ -10,7 +10,7 @@ export function useSeasons(): Season[] {
   // Get seasons to display in the seasons select.
   const { data: seasonsData } = useQueryData(seasonsQuery, {
     variables: {
-      date: format(startOfYear(subYears(currentDate, 5)), DATE_FORMAT),
+      date: getDateString(startOfYear(subYears(currentDate, 5))),
     },
   })
 


### PR DESCRIPTION
Relates to: https://github.com/HSLdevcom/bultti/issues/95

BE PR: https://github.com/HSLdevcom/bultti/pull/169

When creating post inspection results, it's now done by filtering the date options. Other way would be to add possibility to the dropdown to make an item unselectable but maybe leave it for later (make a card if someone proposes it later). Here it would help if the props to our dropdown were typed e.g. IDropdownItem: { key, label, isDisabled }

~~Hmm, I wish we could make InputLabel take hint text as props. Then u could pass hint to a  dropdown that passes it to InputLabel. Make a new card of making <InputLabel /> use <UserHint /> (that wasn't quite simple so I didn't do it here)~~
  - ~~and when this is done, one could add a hint next to dropdown's label if creating pre inspection: "Valittu tarkastusjakso replikoidaan koko viikon ajalle. Valitse aika, jolloin oletat olevan vähiten erikoispäivätyypin liikennettä"~~
  ->**Card**: https://github.com/HSLdevcom/bultti/issues/174

Minor proposals (TODO in this card?)
- ~~should bulttiDate() (that was created in this PR) be used instead of format(date, DATE_FORMAT) everywhere?~~
- ~~- rename readableDate() -> getReadableDate()?~~
- ~~-Fix in a new card: Departure => PlannedDeparture - Create a migraton file that renames departure as planned_departure in db~~- -> Card: https://github.com/HSLdevcom/bultti/issues/171