### PR TITLE
174 hint param to support input label

### DIFF
--- a/src/common/components/form.tsx
+++ b/src/common/components/form.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components/macro'
 import { Column } from './common'
 import { ThemeTypes } from '../../type/common'
+import { observer } from 'mobx-react-lite'
+import UserHint from './UserHint'
+import { CSSProperties } from 'react'
 
 export const FormColumn = styled(Column)`
   padding: 1rem 0;
@@ -29,8 +32,14 @@ export const ControlGroup = styled.div`
     }
   }
 `
-export const InputLabel = styled.label<{ theme: ThemeTypes; subLabel?: boolean }>`
-  display: block;
+
+const InputLabelWrapper = styled.label<{
+  theme?: ThemeTypes
+  subLabel?: boolean
+  hintText?: string
+}>`
+  display: flex;
+  justify-content: space-between;
   font-size: ${(p) => (p.subLabel ? '0.65rem' : '0.875rem')};
   font-weight: bold;
   text-transform: uppercase;
@@ -38,3 +47,22 @@ export const InputLabel = styled.label<{ theme: ThemeTypes; subLabel?: boolean }
   margin: 0;
   padding-bottom: 0.5rem;
 `
+
+type PropTypes = {
+  theme?: ThemeTypes
+  subLabel?: boolean
+  hintText?: string
+  style?: CSSProperties
+  className?: string
+}
+
+export const InputLabel: React.FC<PropTypes> = observer(
+  ({ theme = 'light', subLabel, hintText, children, style = {}, className }) => {
+    return (
+      <InputLabelWrapper theme={theme} subLabel={subLabel} style={style} className={className}>
+        {children}
+        {hintText && <UserHint hintText={hintText} />}
+      </InputLabelWrapper>
+    )
+  }
+)

--- a/src/common/input/Dropdown.tsx
+++ b/src/common/input/Dropdown.tsx
@@ -89,6 +89,7 @@ export type DropdownProps = {
   itemToLabel?: string | ((item: any | null) => string) // property of given object to get label from or a function that returns the label.
   selectedItem?: any // TODO: add documentation of this property or change any
   className?: string
+  hintText?: string
   style?: CSSProperties
   theme?: ThemeTypes
 }
@@ -118,6 +119,7 @@ const Dropdown: React.FC<DropdownProps> = observer(
     items,
     onSelect,
     selectedItem,
+    hintText,
     itemToString = 'id',
     itemToLabel = 'label',
     theme = 'light',
@@ -148,7 +150,7 @@ const Dropdown: React.FC<DropdownProps> = observer(
     return (
       <DropdownView className={className} style={style} theme={theme}>
         {!!label && (
-          <InputLabel {...getLabelProps()} htmlFor="null" theme={theme}>
+          <InputLabel {...getLabelProps()} htmlFor="null" hintText={hintText} theme={theme}>
             {label}
           </InputLabel>
         )}

--- a/src/common/input/Input.tsx
+++ b/src/common/input/Input.tsx
@@ -49,14 +49,14 @@ export const TextArea = styled(TextInput).attrs(() => ({ as: 'textarea', rows: 3
   line-height: 1.4;
   height: auto;
 `
-type InputTypes = 'text' | 'date' | 'number'
+type InputType = 'text' | 'date' | 'number'
 
 export type PropTypes = {
   className?: string
   value: string
   label?: string
   subLabel?: boolean
-  type?: InputTypes
+  type?: InputType
   theme?: ThemeTypes
   hintText?: string
   inputComponent?: React.ComponentType

--- a/src/common/input/Input.tsx
+++ b/src/common/input/Input.tsx
@@ -49,15 +49,17 @@ export const TextArea = styled(TextInput).attrs(() => ({ as: 'textarea', rows: 3
   line-height: 1.4;
   height: auto;
 `
+type InputTypes = 'text' | 'date' | 'number'
 
 export type PropTypes = {
   className?: string
+  value: string
   label?: string
   subLabel?: boolean
-  value: string
   onChange?: (value: string) => unknown
   onEnterPress?: (value?: string) => unknown
   onEscPress?: () => unknown
+  type?: InputTypes
   theme?: ThemeTypes
   inputComponent?: React.ComponentType
   tabIndex?: number
@@ -67,13 +69,13 @@ const Input: React.FC<PropTypes> = observer(
   ({
     className,
     value = '',
-    onChange,
-    theme = 'light',
     label,
     subLabel,
+    onChange,
     onEnterPress,
     onEscPress,
     type = 'text',
+    theme = 'light',
     inputComponent = TextInput,
     tabIndex,
     ...inputProps

--- a/src/common/input/Input.tsx
+++ b/src/common/input/Input.tsx
@@ -56,13 +56,14 @@ export type PropTypes = {
   value: string
   label?: string
   subLabel?: boolean
+  type?: InputTypes
+  theme?: ThemeTypes
+  hintText?: string
+  inputComponent?: React.ComponentType
+  tabIndex?: number
   onChange?: (value: string) => unknown
   onEnterPress?: (value?: string) => unknown
   onEscPress?: () => unknown
-  type?: InputTypes
-  theme?: ThemeTypes
-  inputComponent?: React.ComponentType
-  tabIndex?: number
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'>
 
 const Input: React.FC<PropTypes> = observer(
@@ -71,13 +72,14 @@ const Input: React.FC<PropTypes> = observer(
     value = '',
     label,
     subLabel,
+    type = 'text',
+    theme = 'light',
+    hintText,
+    inputComponent = TextInput,
+    tabIndex,
     onChange,
     onEnterPress,
     onEscPress,
-    type = 'text',
-    theme = 'light',
-    inputComponent = TextInput,
-    tabIndex,
     ...inputProps
   }) => {
     const onValueChange = useCallback(
@@ -109,7 +111,7 @@ const Input: React.FC<PropTypes> = observer(
     return (
       <InputView className={className}>
         {!!label && (
-          <InputLabel subLabel={subLabel} theme={theme}>
+          <InputLabel subLabel={subLabel} theme={theme} hintText={hintText}>
             {label}
           </InputLabel>
         )}

--- a/src/inspection/InspectionMeta.tsx
+++ b/src/inspection/InspectionMeta.tsx
@@ -21,10 +21,6 @@ const InspectionMetaContainer = styled.div`
   margin-top: 1rem;
 `
 
-const MetaHeading = styled(InputLabel).attrs(() => ({ theme: 'light' }))`
-  margin-top: 0;
-`
-
 type PropTypes = {
   className?: string
   inspection: Inspection
@@ -41,14 +37,14 @@ const InspectionMeta: React.FC<PropTypes> = observer(({ className, inspection })
 
   return (
     <InspectionMetaView className={className}>
-      <MetaHeading style={{ display: 'flex', alignItems: 'center', paddingBottom: 0 }}>
+      <InputLabel style={{ justifyContent: 'start', alignItems: 'center', paddingBottom: 0 }}>
         Tarkastuksen tiedot
         <TextButton
           style={{ display: 'inline-block', marginLeft: '1rem' }}
           onClick={toggleMetaVisible}>
           {isVisible ? text('hide') : text('show')}
         </TextButton>
-      </MetaHeading>
+      </InputLabel>
       {isVisible && (
         <InspectionMetaContainer>
           <MetaDisplay>

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -78,6 +78,11 @@ const InspectionSelectDates = observer(
             items={dateOptions}
             onSelect={onSelectDates}
             selectedItem={selectedItem}
+            hintText={
+              inspectionType === InspectionType.Post
+                ? text('inspection_date_postInspectionDateSelectionHint')
+                : undefined
+            }
           />
         )}
       </InspectionSelectDatesView>

--- a/src/postInspection/LoadInspectionHfpData.tsx
+++ b/src/postInspection/LoadInspectionHfpData.tsx
@@ -313,7 +313,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
 
   return (
     <LoadInspectionHfpDataView error={hfpMissing}>
-      <InputLabel theme="light">Lataa HFP</InputLabel>
+      <InputLabel>Lataa HFP</InputLabel>
       <LoadDescription>
         Tarkastukseen tarvitaan suuri määrä HFP tietoa, eli tietoa liikenteen toteumasta. Kun
         olet säätänyt tarkastuksen tarkastusjakso mieleiseksi, lataa toteutunut tieto siltä
@@ -351,9 +351,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
       </div>
       {!loadedRangesLoading && (
         <LoadedRangesDisplay>
-          <InputLabel theme="light" style={{ marginLeft: '1rem' }}>
-            HFP tietojen tilanne
-          </InputLabel>
+          <InputLabel style={{ marginLeft: '1rem' }}>HFP tietojen tilanne</InputLabel>
           {dateStatusByRanges.map((dateStatusRange) => {
             let status = dateStatusRange[0].status
 
@@ -378,7 +376,7 @@ const LoadInspectionHfpData = observer(({ setHfpLoaded }: PropTypes) => {
           })}
           {dateProgress.size !== 0 && (
             <>
-              <InputLabel theme="light" style={{ marginLeft: '1rem', marginTop: '1.5rem' }}>
+              <InputLabel style={{ marginLeft: '1rem', marginTop: '1.5rem' }}>
                 Nyt lataamassa
               </InputLabel>
               {inspectionDates.map((date) => {

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -161,7 +161,7 @@
   "inspection_date.list.header": "Nykyiset tarkastusjaksot",
   "inspection_date.list.noResults": "Tarkastusjaksoja ei löytynyt",
   "inspection_date.form.header": "Lisää uusi tarkastusjakso",
-  "inspection_date_postInspectionDateSelectionHint": "Valittu tarkastusjakso replikoidaan koko viikon ajalle. Valitse aika, jolloin oletat olevan vähiten erikoispäivätyypin liikennettä",
+  "inspection_date_postInspectionDateSelectionHint": "Valittu tarkastusjakso replikoidaan koko viikon ajalle. Valitse aika, jolloin oletat olevan vähiten erikoispäivätyypin liikennettä.",
 
   "report.filtering.add_field": "Lisää kenttä",
   "report.filtering.title": "Suodatus",

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -161,6 +161,7 @@
   "inspection_date.list.header": "Nykyiset tarkastusjaksot",
   "inspection_date.list.noResults": "Tarkastusjaksoja ei löytynyt",
   "inspection_date.form.header": "Lisää uusi tarkastusjakso",
+  "inspection_date_postInspectionDateSelectionHint": "Valittu tarkastusjakso replikoidaan koko viikon ajalle. Valitse aika, jolloin oletat olevan vähiten erikoispäivätyypin liikennettä",
 
   "report.filtering.add_field": "Lisää kenttä",
   "report.filtering.title": "Suodatus",


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/174

Now Input, InputLabel and Dropdown supports hintText param. I think we can make other components support hintText too as we go (should be easy since InputLabel now supports it)

Btw I sorted those Input params. Imo we don't need to nitpick param order in PR's but I wish you could try to put them in some specific order. I usually list the core ones first and then "not so core" props. And I also like to put methods lastly. Could even document this to conventions as "not strict rules" or smth