### PR TITLE
85 table component fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react-dropzone": "^11.2.4",
     "react-fast-compare": "^3.2.0",
     "react-scripts": "^4.0.1",
-    "react-virtualized-auto-sizer": "^1.0.3",
     "react-window": "^1.8.6",
     "styled-components": "^5.2.1",
     "subscriptions-transport-ws": "^0.9.18",

--- a/src/common/components/Button.tsx
+++ b/src/common/components/Button.tsx
@@ -271,11 +271,18 @@ export const StyledRemoveButton = styled.button`
 export type RemoveButtonProps = {
   children?: HTMLCollection | string
   onClick: (e?: React.MouseEvent) => void
+  className?: string
 } & React.ButtonHTMLAttributes<HTMLButtonElement>
 
-export const RemoveButton = ({ onClick, children, ...props }: RemoveButtonProps) => {
+export const RemoveButton = ({
+  onClick,
+  children,
+  style,
+  className,
+  ...props
+}: RemoveButtonProps) => {
   return (
-    <StyledRemoveButton onClick={onClick} {...props}>
+    <StyledRemoveButton onClick={onClick} className={className} {...props}>
       <Trash fill="var(--red)" width="1rem" height="1rem" />
     </StyledRemoveButton>
   )

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -245,7 +245,6 @@ export type PropTypes<ItemType> = {
     onCancel?: () => unknown,
     tabIndex?: number
   ) => React.ReactChild
-  virtualized?: boolean
   maxHeight?: number
   fluid?: boolean // Fluid or calculated-then-static table and columns width
   showToolbar?: boolean // Show toolbar when there are editable values and a save function
@@ -458,7 +457,7 @@ const Table = observer(
     renderValue = defaultRenderValue,
     getColumnTotal,
     className,
-    visibleRowCountOptions = [10, 20, 50],
+    visibleRowCountOptions = [],
     selectedRowCountOption,
     onEditValue,
     onCancelEdit,
@@ -466,7 +465,6 @@ const Table = observer(
     pendingValues = [],
     renderInput = defaultRenderInput,
     editableValues = [],
-    virtualized = false,
     maxHeight = window.innerHeight,
     fluid = false,
     showToolbar = true,
@@ -836,29 +834,11 @@ const Table = observer(
               })}
             </TableHeader>
             <TableBodyWrapper>
-              {tableIsEmpty ? (
-                emptyContent
-              ) : virtualized ? (
-                <List
-                  style={{
-                    minWidth: '100%',
-                    overflowX: 'hidden',
-                    overflowY: hasVerticalScroll ? 'scroll' : 'hidden',
-                  }}
-                  height={height}
-                  width={tableViewWidth}
-                  itemCount={rows.length}
-                  itemSize={rowHeight}
-                  layout="vertical"
-                  itemData={rows}
-                  itemKey={getListItemKey}>
-                  {TableRowComponent}
-                </List>
-              ) : (
-                rowsToRender.map((row, rowIndex) => (
-                  <TableRowComponent key={row.key || rowIndex} row={row} index={rowIndex} />
-                ))
-              )}
+              {tableIsEmpty
+                ? emptyContent
+                : rowsToRender.map((row, rowIndex) => (
+                    <TableRowComponent key={row.key || rowIndex} row={row} index={rowIndex} />
+                  ))}
             </TableBodyWrapper>
             {typeof getColumnTotal === 'function' && (
               <TableRow key="totals" footer={true}>

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -646,7 +646,7 @@ const Table = observer(
       visibleRowCountOptions &&
       !visibleRowCountOptions.includes(selectedRowCountOption)
     ) {
-      throw 'visibleRowCountOptions didnt include given selectedRowCountOption'
+      throw new Error('visibleRowCountOptions did not include given selectedRowCountOption')
     }
     let [selectedRowCount, setSelectedRowCount] = useState<number>(
       selectedRowCountOption ? selectedRowCountOption : visibleRowCountOptions[0]

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -10,8 +10,7 @@ import React, {
 import styled from 'styled-components/macro'
 import { observer } from 'mobx-react-lite'
 import { Dictionary, difference, get, omitBy, orderBy, toString, uniqueId } from 'lodash'
-import { StyledRemoveButton } from './Button'
-import { CrossThick } from '../icon/CrossThick'
+import { RemoveButton } from './Button'
 import { ScrollContext } from './AppFrame'
 import { FixedSizeList as List } from 'react-window'
 import Input, { TextInput } from '../input/Input'
@@ -58,30 +57,11 @@ export const TableTextInput = styled(TextInput).attrs(() => ({ theme: 'light' })
   height: calc(100% + 1px);
 `
 
-const RowRemoveButton = styled(StyledRemoveButton)`
-  width: 2rem;
-  border: 0;
+const RowRemoveButton = styled(RemoveButton)`
   transition: opacity 0.05s ease-out, right 0.1s ease-out;
-  background-color: var(--red);
-  color: white;
-  transform: none;
+  right: -2rem;
   opacity: 0;
   position: absolute;
-  right: -2rem;
-  top: 0;
-  bottom: 0;
-
-  svg * {
-    fill: white;
-  }
-
-  svg *.fill-inverse {
-    fill: var(--red);
-  }
-
-  &:hover {
-    transform: none;
-  }
 `
 
 const TableRow = styled.div<{ isEditing?: boolean; footer?: boolean }>`
@@ -456,9 +436,7 @@ const TableRowComponent = observer(
           />
         ))}
         {onRemoveRow && (
-          <RowRemoveButton onClick={() => onRemoveRow!(row.item)}>
-            <CrossThick fill="white" width="0.5rem" height="0.5rem" />
-          </RowRemoveButton>
+          <RowRemoveButton style={{ opacity: '0' }} onClick={() => onRemoveRow!(row.item)} />
         )}
       </TableRow>
     )

--- a/src/common/components/Table.tsx
+++ b/src/common/components/Table.tsx
@@ -227,7 +227,7 @@ export type PropTypes<ItemType> = {
   onRemoveRow?: (item: ItemType) => void
   className?: string
   visibleRowCountOptions?: number[] // Options to limit number of rows shown. Give an empty array to display all rows
-  selectedRowCountOption?: number // Which of visibleRowCountOptions is selected by default
+  selectedRowCountIndex?: number
   renderCell?: (key: string, val: any, item?: ItemType) => React.ReactNode
   renderValue?: (key: string, val: any, isHeader?: boolean, item?: ItemType) => React.ReactNode
   getColumnTotal?: (key: string) => React.ReactChild
@@ -458,7 +458,7 @@ const Table = observer(
     getColumnTotal,
     className,
     visibleRowCountOptions = [],
-    selectedRowCountOption,
+    selectedRowCountIndex = 0,
     onEditValue,
     onCancelEdit,
     onSaveEdit,
@@ -637,17 +637,9 @@ const Table = observer(
     )
 
     // Variables to handle shown rows per page
-    const areVisibleRowCountOptionsShown = visibleRowCountOptions.length > 1 // selectedRowCountOption
-    // Sanity check
-    if (
-      selectedRowCountOption &&
-      visibleRowCountOptions &&
-      !visibleRowCountOptions.includes(selectedRowCountOption)
-    ) {
-      throw new Error('visibleRowCountOptions did not include given selectedRowCountOption')
-    }
+    const areVisibleRowCountOptionsShown = visibleRowCountOptions.length > 1 // selectedRowCountIndex
     let [selectedRowCount, setSelectedRowCount] = useState<number>(
-      selectedRowCountOption ? selectedRowCountOption : visibleRowCountOptions[0]
+      visibleRowCountOptions[selectedRowCountIndex]
     )
     let [selectedPageIndex, setSelectedPageIndex] = useState<number>(0)
     let rowsToRender = areVisibleRowCountOptionsShown

--- a/src/equipment/EquipmentList.tsx
+++ b/src/equipment/EquipmentList.tsx
@@ -182,6 +182,7 @@ const EquipmentList: React.FC<PropTypes> = observer(
             onCancelEdit={onCancelPendingValue}
             onSaveEdit={updateEquipment ? onSavePendingValue : undefined}
             editableValues={editableValues}
+            visibleRowCountOptions={[10, 20, 50]}
             highlightRow={(item) => (item.requirementOnly ? '#fff4da' : false)}
             renderInput={(key, val, onChange, onAccept, onCancel) => (
               <EquipmentFormInput
@@ -201,6 +202,7 @@ const EquipmentList: React.FC<PropTypes> = observer(
             columnLabels={groupedColumnLabels}
             renderValue={renderCellValue}
             getColumnTotal={renderColumnTotals}
+            visibleRowCountOptions={[10, 20, 50]}
             editableValues={[]}
             onRemoveRow={() =>
               alert(text('catalogue_itemRemovalNotAllowedInGroupedListModeNotification'))

--- a/src/equipment/EquipmentList.tsx
+++ b/src/equipment/EquipmentList.tsx
@@ -39,14 +39,14 @@ const EquipmentList: React.FC<PropTypes> = observer(
     groupedColumnLabels,
     editableValues = [],
   }) => {
-    let [groupEquipment, setEquipmentGrouped] = useState(true)
+    let [isEquipmentShownInGroup, setIsEquipmentShownInGroup] = useState(true)
     let [pendingValues, setPendingValues] = useState<EditValue<EquipmentWithQuota>[]>([])
 
     let getQuotaId = useCallback((item) => `${item.quotaId}_${item.id}`, [])
 
     const onEditValue = useCallback(
       (key: string, value: CellValType, item: EquipmentWithQuota) => {
-        if (groupEquipment || !editableValues.includes(key)) {
+        if (isEquipmentShownInGroup || !editableValues.includes(key)) {
           return
         }
 
@@ -64,7 +64,7 @@ const EquipmentList: React.FC<PropTypes> = observer(
           return [...currentValues, editValue]
         })
       },
-      [groupEquipment, editableValues]
+      [isEquipmentShownInGroup, editableValues]
     )
 
     const onCancelPendingValue = useCallback(() => {
@@ -101,7 +101,7 @@ const EquipmentList: React.FC<PropTypes> = observer(
     }, [updateEquipment, pendingValues])
 
     const onRemoveEquipment = useCallback(
-      (item: EquipmentWithQuota) => () => {
+      (item: EquipmentWithQuota) => {
         if (removeEquipment && confirm(text('catalogue_equipmentConfirmRemove'))) {
           removeEquipment(item.id)
         }
@@ -110,7 +110,7 @@ const EquipmentList: React.FC<PropTypes> = observer(
     )
 
     const onToggleEquipmentGrouped = useCallback((checked: boolean) => {
-      setEquipmentGrouped(checked)
+      setIsEquipmentShownInGroup(checked)
     }, [])
 
     const equipmentGroups: EquipmentQuotaGroup[] = useMemo(
@@ -156,18 +156,20 @@ const EquipmentList: React.FC<PropTypes> = observer(
       [equipment]
     )
 
+    let isEquipmentListEditable = !isEquipmentShownInGroup && orderedEquipment.length !== 0
+
     return equipment.length !== 0 ? (
       <>
         <FlexRow style={{ marginTop: '1rem', marginBottom: '1rem' }}>
           <ToggleButton
             name="grouped-equipment"
             value="grouped"
-            checked={groupEquipment}
+            checked={isEquipmentShownInGroup}
             onChange={onToggleEquipmentGrouped}>
             <Text>catalogue_showGrouped</Text>
           </ToggleButton>
         </FlexRow>
-        {!groupEquipment && orderedEquipment.length !== 0 && (
+        {isEquipmentListEditable && (
           <Table<EquipmentWithQuota>
             items={orderedEquipment}
             keyFromItem={getQuotaId}
@@ -193,13 +195,16 @@ const EquipmentList: React.FC<PropTypes> = observer(
             )}
           />
         )}
-        {groupEquipment && (
+        {isEquipmentShownInGroup && (
           <Table<EquipmentQuotaGroup>
             items={equipmentGroups}
             columnLabels={groupedColumnLabels}
             renderValue={renderCellValue}
             getColumnTotal={renderColumnTotals}
             editableValues={[]}
+            onRemoveRow={() =>
+              alert(text('catalogue_itemRemovalNotAllowedInGroupedListModeNotification'))
+            }
           />
         )}
       </>

--- a/src/equipmentCatalogue/CatalogueEquipmentList.tsx
+++ b/src/equipmentCatalogue/CatalogueEquipmentList.tsx
@@ -108,7 +108,12 @@ const CatalogueEquipmentList: React.FC<PropTypes> = observer(
           editableValues={equipmentEditable ? ['percentageQuota'] : undefined}
         />
         <FlexRow
-          style={{ marginLeft: 'auto', justifyContent: 'flex-end', marginBottom: '1rem' }}>
+          style={{
+            marginLeft: 'auto',
+            justifyContent: 'flex-end',
+            marginBottom: '1rem',
+            marginTop: '1rem',
+          }}>
           <Button loading={equipmentUpdateLoading} onClick={updateAllEquipmentData}>
             <Text>catalogue_updateEquipment</Text>
           </Button>

--- a/src/report/ListReport.tsx
+++ b/src/report/ListReport.tsx
@@ -70,7 +70,6 @@ const ListReport = observer(
     return (
       <ListReportView>
         <Table<ItemType>
-          virtualized={true}
           keyFromItem={(item: any) =>
             item?.id || item?._id || item?.departureId || item?.registryNr || ''
           }

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -37,7 +37,7 @@ const Report = observer(({ reportName, inspectionId, inspectionType }: PropTypes
   let [sort, setSort] = useState<SortConfig[]>([])
   let [page, setPage] = useState<PageConfig>({
     page: 1,
-    pageSize: 500,
+    pageSize: 20,
   })
 
   let requestVars = useRef({
@@ -81,39 +81,6 @@ const Report = observer(({ reportName, inspectionId, inspectionType }: PropTypes
     return report?.columnLabels ? JSON.parse(report?.columnLabels) : undefined
   }, [report])
 
-  let onPageNav = useCallback(
-    (offset) => {
-      return () => {
-        setPage((currentPage) => {
-          let nextPageIdx = Math.min(
-            Math.max(currentPage.page + offset, 1),
-            report?.pages || 1
-          )
-
-          return {
-            ...currentPage,
-            page: nextPageIdx,
-          }
-        })
-      }
-    },
-    [report?.pages]
-  )
-
-  let onSetPage = useCallback(
-    (setPageTo) => {
-      setPage((currentPage) => {
-        let nextPageIdx = Math.min(Math.max(setPageTo, 1), report?.pages || 1)
-
-        return {
-          ...currentPage,
-          page: nextPageIdx,
-        }
-      })
-    },
-    [report?.pages]
-  )
-
   return (
     <ReportView>
       <ReportFunctionsRow>
@@ -143,9 +110,31 @@ const Report = observer(({ reportName, inspectionId, inspectionType }: PropTypes
             onApply={onUpdateFetchProps}
           />
           <ReportPaging
-            onSetPage={onSetPage}
-            onNextPage={onPageNav(1)}
-            onPrevPage={onPageNav(-1)}
+            selectedPageSize={page.pageSize}
+            onSetPage={(targetPageNumber: number) =>
+              setPage({
+                page: targetPageNumber,
+                pageSize: page.pageSize,
+              })
+            }
+            onNextPage={() =>
+              setPage({
+                page: page.page + 1,
+                pageSize: page.pageSize,
+              })
+            }
+            onPrevPage={() =>
+              setPage({
+                page: page.page - 1,
+                pageSize: page.pageSize,
+              })
+            }
+            onSetPageSize={(targetPageSize: number) =>
+              setPage({
+                page: page.page,
+                pageSize: targetPageSize,
+              })
+            }
             reportData={report}
           />
         </>

--- a/src/report/ReportPaging.tsx
+++ b/src/report/ReportPaging.tsx
@@ -52,15 +52,31 @@ const PageSelectDropdown = styled(Dropdown)`
   }
 `
 
+const PageSelectorOption = styled.div`
+  cursor: pointer;
+  color: var(--blue);
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+`
+
 export type PropTypes = {
   reportData: any
-  onNextPage: () => unknown
-  onPrevPage: () => unknown
-  onSetPage: (setToPage: number) => unknown
+  selectedPageSize: number
+  onNextPage: () => void
+  onPrevPage: () => void
+  onSetPage: (targetPageNumber: number) => void
+  onSetPageSize: (targetPageSize: number) => void
 }
 
 const ReportPaging = observer(
-  ({ reportData, onNextPage, onPrevPage, onSetPage }: PropTypes) => {
+  ({
+    reportData,
+    selectedPageSize,
+    onNextPage,
+    onPrevPage,
+    onSetPage,
+    onSetPageSize,
+  }: PropTypes) => {
     let pageOptions = useMemo(() => {
       let opts: number[] = []
       let pageIdx = 1
@@ -71,6 +87,14 @@ const ReportPaging = observer(
 
       return opts
     }, [reportData.pages])
+
+    let pageSizeOptions = [20, 50, 100]
+
+    let selectedPageOptionStyles = {
+      color: 'var(--dark-grey)',
+      cursor: 'default',
+      fontWeight: 'bold' as 'bold',
+    }
 
     return (
       <ReportPagingView>
@@ -83,7 +107,17 @@ const ReportPaging = observer(
           </PageValue>
         )}
         <PageValue>
-          Rivejä per sivu: <strong>{reportData.page?.pageSize}</strong>
+          Näytä
+          {pageSizeOptions.map((option: number, index: number) => {
+            return (
+              <PageSelectorOption
+                key={`option-${index}`}
+                onClick={() => onSetPageSize(option)}
+                style={selectedPageSize === option ? selectedPageOptionStyles : {}}>
+                {option}
+              </PageSelectorOption>
+            )
+          })}
         </PageValue>
         {reportData.page?.pageSize !== reportData.reportData?.length && (
           <PageValue>

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -12,6 +12,8 @@
   "remove": "Poista",
   "cancel": "Peruuta",
   "save": "Tallenna",
+  "next": "Seuraava",
+  "previous": "Edellinen",
   "field": "Kenttä",
   "add": "Lisää",
   "area": "Alue",
@@ -36,6 +38,8 @@
   "departureBlocks": "Lähtöketjut",
   "vehicleId": "Kylkinumero",
   "registryNumber": "Rekisterinumero",
+
+  "table_rowsPerPage": "riviä per sivu",
 
   "nav_editProcurementUnits": "Muokkaa kilpailukohteita",
   "nav_editInspectionDates": "Muokkaa tarkistusjaksoja",

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -112,6 +112,7 @@
   "catalogue_addCatalogue": "Lisää kalustoluettelo",
   "catalogue_cataloguesListHeading": "Kalustoluettelot",
   "catalogue_showGrouped": "Näytä ryhmissä",
+  "catalogue_itemRemovalNotAllowedInGroupedListModeNotification": "Poistaaksesi ajoneuvon, näytä ajoneuvot ilman ryhmiä ensin.",
   "catalogue_updateEquipment": "Päivitä ajoneuvotiedot JOREsta",
   "catalogue_removeAllEquipment": "Poista kaikki ajoneuvot luettelosta",
   "catalogue_removeEquipment": "Poista kalustoluettelo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11514,11 +11514,6 @@ react-scripts@^4.0.1:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react-virtualized-auto-sizer@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.3.tgz#a491577dc70102b9faaef473d640437eab9db120"
-  integrity sha512-HnJo3Hk5Ky2TUL2GpLOs5sKiyskFwdNllI3P5Mp0tgFatz6ClnEG1gnK76/NhSkd/3YtYPTVjIsINYVBd/fRxw==
-
 react-window@^1.8.6:
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
@@ -13787,10 +13782,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Closes: https://github.com/HSLdevcom/bultti/issues/85

CSS Note: I wish I could disable hover for options with selectedPageOptionStyles style object. Didn't figure out an easy way to do that.

How the idea works:
You can pass to <Table>:
visibleRowCountOptions={[]} // to show all elements
visibleRowCountOptions={[5, 10]} // to show 5 / 10 elements per page options
visibleRowCountOptions={undefined} // when not passing visibleRowCountOptions, default 10, 20, 50 options are shown
selectedRowCountOption={20} // option 20 is selected by default
selectedRowCountOption={19} // throws an error if option 19 is not found

Note: Logic changed a bit when refactored remove button related things:

{!isEditingRow && removeItem && ( <RowRemoveButton>...
--> is now just
{onRemoveRow && ( <RowRemoveButton>...
didn't see a reason why we would want to hide remove button when editing row