### PR TITLE
150 inspection update button fixes

### DIFF
--- a/src/common/components/Loading.tsx
+++ b/src/common/components/Loading.tsx
@@ -8,7 +8,7 @@ const spin = keyframes`
   from {
     transform: rotate(0deg);
   }
-  
+
   to {
     transform: rotate(360deg);
   }

--- a/src/common/components/Messages.tsx
+++ b/src/common/components/Messages.tsx
@@ -30,6 +30,6 @@ export const ErrorView = styled(MessageView)`
 `
 
 export const EmptyView = styled(MessageView)`
-  background: #f8f8f8;
+  background: var(--disabled-grey);
   border-color: #ccc;
 `

--- a/src/common/components/Typography.tsx
+++ b/src/common/components/Typography.tsx
@@ -10,7 +10,6 @@ export const Heading = styled.h3`
 
 export const SectionHeading = styled(Heading)`
   margin-top: 2rem;
-  user-select: none;
   color: var(--dark-grey);
 
   &:first-child {

--- a/src/common/input/Dropdown.tsx
+++ b/src/common/input/Dropdown.tsx
@@ -21,6 +21,7 @@ const SelectButton = styled(Button).attrs({ size: ButtonSize.MEDIUM })<{
   background: ${(p) => (p.disabled ? 'transparent' : 'white')};
   color: ${(p) =>
     p.disabled ? (p.theme === 'light' ? 'var(--dark-grey)' : 'white') : 'var(--dark-grey)'};
+  background: ${(p) => (p.disabled ? 'var(--disabled-grey)' : 'white')};
   width: 100%;
   padding: 0.75rem 1rem 0.75rem 1rem;
   border-radius: 8px;

--- a/src/common/input/Input.tsx
+++ b/src/common/input/Input.tsx
@@ -13,7 +13,11 @@ export const TextInput = styled.input<{
 }>`
   font-family: var(--font-family);
   background: ${(p) =>
-    p.theme === 'light' ? (p.readOnly || p.disabled ? '#f8f8f8' : 'white') : 'white'};
+    p.theme === 'light'
+      ? p.readOnly || p.disabled
+        ? 'var(--disabled-grey)'
+        : 'white'
+      : 'white'};
   color: var(--dark-grey);
   width: 100%;
   padding: 0.75rem;

--- a/src/departureBlock/DepartureBlocks.tsx
+++ b/src/departureBlock/DepartureBlocks.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useMemo } from 'react'
 import styled from 'styled-components/macro'
 import { observer } from 'mobx-react-lite'
 import { difference } from 'lodash'
-import { Button, ButtonSize, ButtonStyle } from '../common/components/Button'
+import { Button } from '../common/components/Button'
 import { defaultDayTypeGroup, useDayTypeGroups } from './departureBlocksCommon'
 import DepartureBlockGroupItem from './DepartureBlockGroupItem'
 import { useQueryData } from '../util/useQueryData'
@@ -10,10 +10,7 @@ import { availableDayTypesQuery } from './blockDeparturesQuery'
 import { normalDayTypes } from '../constants'
 import { InspectionContext } from '../inspection/InspectionContext'
 import { useRefetch } from '../util/useRefetch'
-import ExpandableSection, {
-  HeaderMainHeading,
-  HeaderSection,
-} from '../common/components/ExpandableSection'
+import ExpandableSection, { HeaderMainHeading } from '../common/components/ExpandableSection'
 import { Text } from '../util/translate'
 
 const DepartureBlocksView = styled.div`
@@ -86,23 +83,9 @@ const DepartureBlocks: React.FC<PropTypes> = observer(({ isEditable, onUpdate, i
     <ExpandableSection
       error={!isValid}
       headerContent={
-        <>
-          <HeaderMainHeading>
-            <Text>departureBlocks</Text>
-          </HeaderMainHeading>
-          <HeaderSection style={{ padding: '0.5rem 0.75rem', justifyContent: 'center' }}>
-            {dayTypesWithDepartures.length !== 0 && (
-              <Button
-                loading={departureBlocksLoading}
-                style={{ marginLeft: 'auto' }}
-                buttonStyle={ButtonStyle.SECONDARY}
-                size={ButtonSize.SMALL}
-                onClick={() => refetch()}>
-                <Text>update</Text>
-              </Button>
-            )}
-          </HeaderSection>
-        </>
+        <HeaderMainHeading>
+          <Text>departureBlocks</Text>
+        </HeaderMainHeading>
       }>
       <DepartureBlocksView>
         {dayTypeGroups.map((dayTypeGroup, groupIndex) => {

--- a/src/executionRequirement/PlannedExecutionStats.tsx
+++ b/src/executionRequirement/PlannedExecutionStats.tsx
@@ -14,7 +14,6 @@ import { text, Text } from '../util/translate'
 import { SmallHeading } from '../common/components/Typography'
 import { orderBy } from 'lodash'
 import { normalDayTypes } from '../constants'
-import { Button, ButtonSize, ButtonStyle } from '../common/components/Button'
 import { FlexRow } from '../common/components/common'
 
 const PlannedExecutionStatsView = styled.div`
@@ -51,7 +50,7 @@ export type PropTypes = {
 }
 
 const PlannedExecutionStats = observer(({ executionRequirement }: PropTypes) => {
-  let { data: executionStatsData, refetch } = useQueryData<ExecutionSchemaStats>(
+  let { data: executionStatsData } = useQueryData<ExecutionSchemaStats>(
     executionSchemaStatsQuery,
     {
       skip: !executionRequirement,
@@ -71,14 +70,6 @@ const PlannedExecutionStats = observer(({ executionRequirement }: PropTypes) => 
 
   return (
     <PlannedExecutionStatsView>
-      <FlexRow style={{ marginTop: '1.5rem' }}>
-        <Button
-          buttonStyle={ButtonStyle.SECONDARY}
-          size={ButtonSize.SMALL}
-          onClick={() => refetch()}>
-          <Text>update</Text>
-        </Button>
-      </FlexRow>
       <FlexRow>
         <TableWrapper>
           <SmallHeading style={{ marginTop: '0.5rem' }}>

--- a/src/executionRequirement/PreInspectionExecutionRequirements.tsx
+++ b/src/executionRequirement/PreInspectionExecutionRequirements.tsx
@@ -1,15 +1,12 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components/macro'
 import { observer } from 'mobx-react-lite'
-import { Button, ButtonSize, ButtonStyle } from '../common/components/Button'
+import { Button } from '../common/components/Button'
 import RequirementsTable from './RequirementsTable'
 import { LoadingDisplay } from '../common/components/Loading'
 import { InspectionContext } from '../inspection/InspectionContext'
 import { MessageView } from '../common/components/Messages'
-import ExpandableSection, {
-  HeaderMainHeading,
-  HeaderSection,
-} from '../common/components/ExpandableSection'
+import ExpandableSection, { HeaderMainHeading } from '../common/components/ExpandableSection'
 import {
   RequirementsTableLayout,
   usePreInspectionAreaRequirements,
@@ -52,25 +49,17 @@ const PreInspectionExecutionRequirements: React.FC<PropTypes> = observer(
             <HeaderMainHeading>
               <Text>executionRequirements</Text>
             </HeaderMainHeading>
-            <HeaderSection style={{ padding: '0.5rem 0.75rem', justifyContent: 'center' }}>
-              {areaExecutionRequirements?.length !== 0 && (
-                <Button
-                  loading={requirementsLoading}
-                  style={{ marginLeft: 'auto' }}
-                  buttonStyle={ButtonStyle.SECONDARY}
-                  size={ButtonSize.SMALL}
-                  onClick={refetch}>
-                  <Text>update</Text>
-                </Button>
-              )}
-            </HeaderSection>
           </>
         }>
         {!requirementsLoading && areaExecutionRequirements?.length === 0 && (
           <>
-            <MessageView>Suoritevaatimukset ei laskettu.</MessageView>
+            <MessageView>
+              <Text>preInspection_noCalculatedExecutionRequirements</Text>
+            </MessageView>
             <div>
-              <Button onClick={refetch}>Laske suoritevaatimukset ja toteumat</Button>
+              <Button onClick={refetch}>
+                <Text>preInspection_calculateExecutionRequirements</Text>
+              </Button>
             </div>
           </>
         )}

--- a/src/executionRequirement/PreInspectionExecutionRequirements.tsx
+++ b/src/executionRequirement/PreInspectionExecutionRequirements.tsx
@@ -45,11 +45,9 @@ const PreInspectionExecutionRequirements: React.FC<PropTypes> = observer(
       <ExpandableSection
         error={!isValid}
         headerContent={
-          <>
-            <HeaderMainHeading>
-              <Text>executionRequirements</Text>
-            </HeaderMainHeading>
-          </>
+          <HeaderMainHeading>
+            <Text>executionRequirements</Text>
+          </HeaderMainHeading>
         }>
         {!requirementsLoading && areaExecutionRequirements?.length === 0 && (
           <>

--- a/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
+++ b/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
@@ -181,8 +181,6 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
       [inspection]
     )
 
-    let isLoading = requirementsLoading || createLoading || refreshLoading
-
     return (
       <ProcurementUnitExecutionRequirementView isInvalid={!valid}>
         <FlexRow style={{ marginBottom: '1rem', justifyContent: 'flex-start' }}>
@@ -190,13 +188,6 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
             <Text>executionRequirement_unitExecutionRequirements</Text>
           </SectionHeading>
           <div style={{ display: 'flex', marginLeft: 'auto' }}>
-            <Button
-              loading={isLoading}
-              onClick={update}
-              buttonStyle={ButtonStyle.SECONDARY}
-              size={ButtonSize.SMALL}>
-              <Text>update</Text>
-            </Button>
             {isEditable && (
               <Button
                 loading={refreshLoading}

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,8 @@
   --lightest-grey: #eaeaea;
   --white-grey: #f5f5f5;
 
+  --disabled-grey: #f8f8f8;
+
   --font-family: 'Gotham Rounded SSm A', 'Gotham Rounded SSm B', sans-serif;
 }
 

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -91,6 +91,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(
             <FlexRow>
               <InspectionSelectDates
                 inspectionType={inspection.inspectionType}
+                isEditingDisabled={inspection.status !== InspectionStatus.Draft}
                 inspectionInput={pendingInspectionInputValues}
                 onChange={(startDate: Date, endDate: Date) => {
                   onUpdateValue('inspectionStartDate', getDateString(startDate))

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -21,126 +21,123 @@ const InspectionConfigView = styled(PageSection)`
 
 export type PropTypes = {
   inspection: Inspection
-  isEditable: boolean
   saveValues: (updatedValues: InspectionInput) => Promise<unknown>
 }
 
-const InspectionConfig: React.FC<PropTypes> = observer(
-  ({ saveValues, isEditable, inspection }) => {
-    let getInspectionInputValues = (setFromInspection: Inspection) => {
-      return {
-        name: setFromInspection.name || '',
-        inspectionStartDate: setFromInspection.inspectionStartDate || '',
-        inspectionEndDate: setFromInspection.inspectionEndDate || '',
-      }
+const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection }) => {
+  let getInspectionInputValues = (setFromInspection: Inspection) => {
+    return {
+      name: setFromInspection.name || '',
+      inspectionStartDate: setFromInspection.inspectionStartDate || '',
+      inspectionEndDate: setFromInspection.inspectionEndDate || '',
     }
+  }
 
-    let initialInspectionInputValues = getInspectionInputValues(inspection)
+  let initialInspectionInputValues = getInspectionInputValues(inspection)
 
-    let [
-      pendingInspectionInputValues,
-      setPendingInspectionInputValues,
-    ] = useState<InspectionInput>(initialInspectionInputValues)
+  let [
+    pendingInspectionInputValues,
+    setPendingInspectionInputValues,
+  ] = useState<InspectionInput>(initialInspectionInputValues)
 
-    let onUpdateValue = useCallback((name: string, value: any) => {
-      setPendingInspectionInputValues((currentValues) => {
-        let nextValues: InspectionInput = { ...currentValues }
-        nextValues[name] = value
-        return nextValues
-      })
-    }, [])
+  let onUpdateValue = useCallback((name: string, value: any) => {
+    setPendingInspectionInputValues((currentValues) => {
+      let nextValues: InspectionInput = { ...currentValues }
+      nextValues[name] = value
+      return nextValues
+    })
+  }, [])
 
-    let onSave = useCallback(async () => {
-      await saveValues(pendingInspectionInputValues!)
-    }, [pendingInspectionInputValues])
+  let onSave = useCallback(async () => {
+    await saveValues(pendingInspectionInputValues!)
+  }, [pendingInspectionInputValues])
 
-    let isDirty = useMemo(
-      () =>
-        !isEqual(
-          // Pick only props existing on the pending inspection input for comparison
-          pick(inspection, Object.keys(pendingInspectionInputValues)),
-          pendingInspectionInputValues
-        ),
-      [pendingInspectionInputValues]
-    )
+  let isDirty = useMemo(
+    () =>
+      !isEqual(
+        // Pick only props existing on the pending inspection input for comparison
+        pick(inspection, Object.keys(pendingInspectionInputValues)),
+        pendingInspectionInputValues
+      ),
+    [pendingInspectionInputValues, inspection]
+  )
 
-    return (
-      <InspectionConfigView>
-        {!inspection ? (
-          <MessageContainer>
-            <MessageView>
-              <Text>inspection_inspectionNotSelected</Text>
-            </MessageView>
-          </MessageContainer>
-        ) : (
-          <>
-            <FlexRow>
-              <FormColumn>
-                <Input
-                  value={pendingInspectionInputValues.name || ''}
-                  label={text('inspection_inspectionName')}
-                  onChange={(value: string) => {
-                    onUpdateValue('name', value)
-                  }}
-                />
-              </FormColumn>
-            </FlexRow>
-            <FlexRow>
-              <InspectionTimeline currentInspection={inspection} />
-            </FlexRow>
-            <FlexRow>
-              <InspectionSelectDates
-                inspectionType={inspection.inspectionType}
-                isEditingDisabled={inspection.status !== InspectionStatus.Draft}
-                inspectionInput={pendingInspectionInputValues}
-                onChange={(startDate: Date, endDate: Date) => {
-                  onUpdateValue('inspectionStartDate', getDateString(startDate))
-                  onUpdateValue('inspectionEndDate', getDateString(endDate))
+  return (
+    <InspectionConfigView>
+      {!inspection ? (
+        <MessageContainer>
+          <MessageView>
+            <Text>inspection_inspectionNotSelected</Text>
+          </MessageView>
+        </MessageContainer>
+      ) : (
+        <>
+          <FlexRow>
+            <FormColumn>
+              <Input
+                value={pendingInspectionInputValues.name || ''}
+                label={text('inspection_inspectionName')}
+                onChange={(value: string) => {
+                  onUpdateValue('name', value)
                 }}
               />
-            </FlexRow>
-            <FlexRow>
-              {inspection.status !== InspectionStatus.Draft && (
-                <FormColumn>
-                  <InputLabel theme="light">{text('inspection_inspectionSeason')}</InputLabel>
-                  <ControlGroup>
-                    <Input
-                      type="date"
-                      value={inspection.startDate}
-                      label={text('startDate')}
-                      subLabel={true}
-                      disabled={true}
-                    />
-                    <Input
-                      type="date"
-                      value={inspection.endDate}
-                      label={text('endDate')}
-                      subLabel={true}
-                      disabled={true}
-                    />
-                  </ControlGroup>
-                </FormColumn>
-              )}
-            </FlexRow>
-            <FlexRow>
-              <ActionsWrapper>
-                <Button style={{ marginRight: '1rem' }} onClick={onSave} disabled={!isDirty}>
-                  <Text>save</Text>
-                </Button>
-                <Button
-                  buttonStyle={ButtonStyle.SECONDARY_REMOVE}
-                  onClick={() =>
-                    setPendingInspectionInputValues(getInspectionInputValues(inspection))
-                  }>
-                  <Text>cancel</Text>
-                </Button>
-              </ActionsWrapper>
-            </FlexRow>
-          </>
-        )}
-      </InspectionConfigView>
-    )
-  }
-)
+            </FormColumn>
+          </FlexRow>
+          <FlexRow>
+            <InspectionTimeline currentInspection={inspection} />
+          </FlexRow>
+          <FlexRow>
+            <InspectionSelectDates
+              inspectionType={inspection.inspectionType}
+              isEditingDisabled={inspection.status !== InspectionStatus.Draft}
+              inspectionInput={pendingInspectionInputValues}
+              onChange={(startDate: Date, endDate: Date) => {
+                onUpdateValue('inspectionStartDate', getDateString(startDate))
+                onUpdateValue('inspectionEndDate', getDateString(endDate))
+              }}
+            />
+          </FlexRow>
+          <FlexRow>
+            {inspection.status !== InspectionStatus.Draft && (
+              <FormColumn>
+                <InputLabel theme="light">{text('inspection_inspectionSeason')}</InputLabel>
+                <ControlGroup>
+                  <Input
+                    type="date"
+                    value={inspection.startDate}
+                    label={text('startDate')}
+                    subLabel={true}
+                    disabled={true}
+                  />
+                  <Input
+                    type="date"
+                    value={inspection.endDate}
+                    label={text('endDate')}
+                    subLabel={true}
+                    disabled={true}
+                  />
+                </ControlGroup>
+              </FormColumn>
+            )}
+          </FlexRow>
+          <FlexRow>
+            <ActionsWrapper>
+              <Button style={{ marginRight: '1rem' }} onClick={onSave} disabled={!isDirty}>
+                <Text>save</Text>
+              </Button>
+              <Button
+                buttonStyle={ButtonStyle.SECONDARY_REMOVE}
+                onClick={() =>
+                  setPendingInspectionInputValues(getInspectionInputValues(inspection))
+                }>
+                <Text>cancel</Text>
+              </Button>
+            </ActionsWrapper>
+          </FlexRow>
+        </>
+      )}
+    </InspectionConfigView>
+  )
+})
 
 export default InspectionConfig

--- a/src/inspection/InspectionEditor.tsx
+++ b/src/inspection/InspectionEditor.tsx
@@ -13,7 +13,6 @@ import { LoadingDisplay } from '../common/components/Loading'
 import InspectionUsers from './InspectionUsers'
 import PostInspectionEditor from '../postInspection/PostInspectionEditor'
 import PreInspectionEditor from '../preInspection/PreInspectionEditor'
-import { pick } from 'lodash'
 import InspectionValidationErrors from './InspectionValidationErrors'
 
 const EditInspectionView = styled.div`
@@ -49,39 +48,21 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
 
     let isLoading = useMemo(() => loading || updateLoading, [loading, updateLoading])
 
-    // Update the pre-inspection on changes
     let updatePreInspectionCb = useCallback(
       async (updatedValues: InspectionInput = {}) => {
-        if (Object.keys(updatedValues).length === 0) {
-          return
-        }
+        isUpdating.current = true
 
-        let updateValues = updatedValues
+        await updatePreInspection({
+          variables: {
+            inspectionId: inspection.id,
+            inspectionInput: updatedValues,
+          },
+        })
 
-        if (!isEditable) {
-          updatedValues = pick(updateValues, 'name')
-        }
-
-        if (
-          Object.keys(updateValues).length !== 0 &&
-          !isUpdating.current &&
-          inspection &&
-          !loading
-        ) {
-          isUpdating.current = true
-
-          await updatePreInspection({
-            variables: {
-              inspectionId: inspection.id,
-              inspectionInput: updatedValues,
-            },
-          })
-
-          isUpdating.current = false
-          await refetchData()
-        }
+        isUpdating.current = false
+        await refetchData()
       },
-      [isUpdating.current, inspection, loading, updatePreInspection, refetchData]
+      [isUpdating.current, inspection, updatePreInspection, refetchData]
     )
 
     useEffect(() => {
@@ -116,11 +97,7 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
           <>
             <InspectionMeta inspection={inspection} />
             <InspectionUsers inspection={inspection} />
-            <InspectionConfig
-              inspection={inspection}
-              isEditable={isEditable}
-              saveValues={updatePreInspectionCb}
-            />
+            <InspectionConfig inspection={inspection} saveValues={updatePreInspectionCb} />
             <InspectionTypeEditor
               inspection={inspection}
               isEditable={isEditable}

--- a/src/inspection/InspectionEditor.tsx
+++ b/src/inspection/InspectionEditor.tsx
@@ -50,7 +50,7 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
     let isLoading = useMemo(() => loading || updateLoading, [loading, updateLoading])
 
     // Update the pre-inspection on changes
-    var updatePreInspectionValues = useCallback(
+    let updatePreInspectionCb = useCallback(
       async (updatedValues: InspectionInput = {}) => {
         if (Object.keys(updatedValues).length === 0) {
           return
@@ -82,11 +82,6 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
         }
       },
       [isUpdating.current, inspection, loading, updatePreInspection, refetchData]
-    )
-
-    let createUpdateCallback = useCallback(
-      (updatedValues: InspectionInput) => updatePreInspectionValues(updatedValues),
-      [updatePreInspectionValues]
     )
 
     useEffect(() => {
@@ -124,7 +119,7 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
             <InspectionConfig
               inspection={inspection}
               isEditable={isEditable}
-              saveValues={createUpdateCallback}
+              saveValues={updatePreInspectionCb}
             />
             <InspectionTypeEditor
               inspection={inspection}

--- a/src/inspection/InspectionUsers.tsx
+++ b/src/inspection/InspectionUsers.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback } from 'react'
 import { observer } from 'mobx-react-lite'
-import { Button, ButtonSize, ButtonStyle } from '../common/components/Button'
 import { useStateValue } from '../state/useAppState'
-import ExpandableSection, {
-  HeaderMainHeading,
-  HeaderSection,
-} from '../common/components/ExpandableSection'
+import ExpandableSection, { HeaderMainHeading } from '../common/components/ExpandableSection'
 import { useMutationData } from '../util/useMutationData'
 import {
   inspectionUserRelationsQuery,
@@ -16,7 +12,6 @@ import { LoadingDisplay } from '../common/components/Loading'
 import { useRefetch } from '../util/useRefetch'
 import UserRelations from '../common/components/UserRelations'
 import { Inspection, InspectionUserRelation } from '../schema-types'
-import { Text } from '../util/translate'
 
 export type PropTypes = {
   inspection: Inspection
@@ -57,15 +52,6 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
       headerContent={
         <>
           <HeaderMainHeading>Tarkastuksen tiedot</HeaderMainHeading>
-          <HeaderSection style={{ padding: '0.5rem 0.75rem', justifyContent: 'center' }}>
-            <Button
-              style={{ marginLeft: 'auto' }}
-              buttonStyle={ButtonStyle.SECONDARY}
-              size={ButtonSize.SMALL}
-              onClick={refetchRelations}>
-              <Text>update</Text>
-            </Button>
-          </HeaderSection>
         </>
       }>
       <LoadingDisplay loading={relationsLoading} />

--- a/src/inspection/InspectionUsers.tsx
+++ b/src/inspection/InspectionUsers.tsx
@@ -49,11 +49,7 @@ const InspectionUsers: React.FC<PropTypes> = observer(({ inspection }) => {
   return (
     <ExpandableSection
       isExpanded={true}
-      headerContent={
-        <>
-          <HeaderMainHeading>Tarkastuksen tiedot</HeaderMainHeading>
-        </>
-      }>
+      headerContent={<HeaderMainHeading>Tarkastuksen tiedot</HeaderMainHeading>}>
       <LoadingDisplay loading={relationsLoading} />
       <UserRelations
         relations={inspectionUserRelations}

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -25,13 +25,14 @@ interface DateOption {
 }
 
 export type PropTypes = {
+  isEditingDisabled: boolean
   inspectionType: InspectionType
   inspectionInput: InspectionInput
   onChange: (startDate: Date, endDate: Date) => void
 }
 
 const InspectionSelectDates = observer(
-  ({ inspectionType, inspectionInput, onChange }: PropTypes) => {
+  ({ isEditingDisabled, inspectionType, inspectionInput, onChange }: PropTypes) => {
     let {
       data: inspectionDatesQueryResult,
       loading: areInspectionDatesLoading,
@@ -74,6 +75,7 @@ const InspectionSelectDates = observer(
           <LoadingDisplay />
         ) : (
           <Dropdown
+            disabled={isEditingDisabled}
             label={text('inspection_selectInspection')}
             items={dateOptions}
             onSelect={onSelectDates}

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -130,7 +130,7 @@
 
   "inspection_inspectionNotSelected": "Tarkastusta ei ole valittu.",
   "inspection_inspectionName": "Tarkastuksen nimi",
-  "inspection_selectInspection": "Valitse tarkastusjakso",
+  "inspection_selectInspection": "Tarkastusjakso",
   "inspection_inspectionSeason": "Tuotantojakso",
   "inspection_state_draft": "Muokattavissa",
   "inspection_state_prosessing": "Käsiteltävänä",

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -153,6 +153,9 @@
   "inspectionDateForm_header": "Lisää uusi tarkastusjakso",
   "inspection_date_postInspectionDateSelectionHint": "Valittu tarkastusjakso replikoidaan koko viikon ajalle. Valitse aika, jolloin oletat olevan vähiten erikoispäivätyypin liikennettä.",
 
+  "preInspection_noCalculatedExecutionRequirements": "Ei laskettuja suoritevaatimuksia",
+  "preInspection_calculateExecutionRequirements": "Laske suoritevaatimukset ja toteumat",
+
   "report_filtering_addField": "Lisää kenttä",
   "report_filtering_title": "Suodatus",
   "report_filtering_filter_on": "Suodata saraketta",


### PR DESCRIPTION
Closes: https://github.com/HSLdevcom/bultti/issues/150

Found 2 bugs and fixed them:
* Bug 1: Pre inspection name startDate / endDate saving didnt work
  * The reason for this was simple. Found from BE inspectionResolver: "Allow only name update if inspection is not in draft state."
  --> Had to just disable editing dates if not in DRAFT mode
* Bug 2: When date saved, isDirty didn't get updated (save button was active even after saving)

Removed update buttons from Inspection pages
  * yes, didn't remove procurementUnit update button because it's being used at procurementUnit page and it does have a job there - instead that update button should be moved to the header in procurementUnit page (should I do it here?)
  
Note: also refactored updateInspectionCb - removed useless code
  * the idea in a save method is that it shouldn't be called when a form is not dirty. So saveCb is just a save call