### PR TITLE
206 inspection date range selection fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ src/data
 
 # Visual Studio Code
 .vscode
+
+# Webstorm
+.idea

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -3145,6 +3145,45 @@
             "deprecationReason": null
           },
           {
+            "name": "getObservedInspectionDates",
+            "description": null,
+            "args": [
+              {
+                "name": "seasonId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InspectionDate",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "inspectionSanctions",
             "description": null,
             "args": [

--- a/src/inspection/inspectionDate/inspectionDateQuery.ts
+++ b/src/inspection/inspectionDate/inspectionDateQuery.ts
@@ -17,6 +17,15 @@ export const allInspectionDatesQuery = gql`
   ${InspectionDateFragment}
 `
 
+export const getObservedInspectionDatesQuery = gql`
+  query getObservedInspectionDates($seasonId: String!) {
+    getObservedInspectionDates(seasonId: $seasonId) {
+      ...InspectionDateFragment
+    }
+  }
+  ${InspectionDateFragment}
+`
+
 export const createInspectionDateMutation = gql`
   mutation createInspectionDate($inspectionDateInput: InspectionDateInput!) {
     createInspectionDate(inspectionDate: $inspectionDateInput) {

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -82,6 +82,7 @@ export type Query = {
   observedExecutionRequirements: Array<ObservedExecutionRequirement>;
   previewObservedRequirement?: Maybe<ObservedExecutionRequirement>;
   allInspectionDates: Array<InspectionDate>;
+  getObservedInspectionDates: Array<InspectionDate>;
   inspectionSanctions: SanctionsResponse;
   runSanctioning: Array<Sanction>;
 };
@@ -436,6 +437,11 @@ export type QueryObservedExecutionRequirementsArgs = {
 
 export type QueryPreviewObservedRequirementArgs = {
   requirementId: Scalars['String'];
+};
+
+
+export type QueryGetObservedInspectionDatesArgs = {
+  seasonId: Scalars['String'];
 };
 
 


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/206

* When merged, this card can be removed: https://github.com/HSLdevcom/bultti/issues/224
* I removed check from filtering observed date options "Only dates that are older than 1 month are valid"
   * As now the first inspection date is selected by default, I see no reason to filter here (because invalid value could still end up as being selected because of the default selection). Instead, before prosessing inspections, we should validate that the currently selected inspectionStartDate & inspectionEndDate are valid. In which card should we document this change?

* If date range doesnt exist for a season creating post inspection, an error is thrown. Card to localize this (and other) messages: https://github.com/HSLdevcom/bultti/issues/227