### PR TITLE
208 fix unsaved changes prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ src/data
 
 # Visual Studio Code
 .vscode
+
+# Webstorm
+.idea

--- a/src/equipmentCatalogue/EditEquipmentCatalogue.tsx
+++ b/src/equipmentCatalogue/EditEquipmentCatalogue.tsx
@@ -149,11 +149,12 @@ const EditEquipmentCatalogue = observer(
       )
     }, [])
 
-    let isDirty = !isEqual(
-      { startDate: catalogue?.startDate, endDate: catalogue?.endDate },
-      pendingCatalogue
-    )
-
+    let isDirty =
+      !!pendingCatalogue &&
+      !isEqual(
+        { startDate: catalogue?.startDate, endDate: catalogue?.endDate },
+        pendingCatalogue
+      )
     return (
       <EditEquipmentCatalogueView>
         <>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import Input from '../common/input/Input'
-import { isEqual, pick } from 'lodash'
+import { isEqual, pick, uniqueId } from 'lodash'
 import { ControlGroup, FormColumn, InputLabel } from '../common/components/form'
 import { Inspection, InspectionInput, InspectionStatus } from '../schema-types'
 import { MessageContainer, MessageView } from '../common/components/Messages'
@@ -13,6 +13,7 @@ import InspectionTimeline from './InspectionTimeline'
 import InspectionSelectDates from './inspectionSelectDates'
 import { getDateString } from '../util/formatDate'
 import { Text, text } from '../util/translate'
+import { usePromptUnsavedChanges } from '../util/promptUnsavedChanges'
 
 const InspectionConfigView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -61,6 +62,9 @@ const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection
       ),
     [pendingInspectionInputValues, inspection]
   )
+
+  const formId = useMemo(() => uniqueId(), [])
+  usePromptUnsavedChanges({ uniqueComponentId: formId, shouldShowPrompt: isDirty })
 
   return (
     <InspectionConfigView>

--- a/src/util/promptUnsavedChanges.ts
+++ b/src/util/promptUnsavedChanges.ts
@@ -21,8 +21,12 @@ export const usePromptUnsavedChanges = ({
     } else {
       nextUnsavedIds = nextUnsavedIds.filter((id) => id !== uniqueComponentId)
     }
-
     setUnsavedFormIds(nextUnsavedIds)
+
+    return () => {
+      nextUnsavedIds = nextUnsavedIds.filter((id) => id !== uniqueComponentId)
+      setUnsavedFormIds(nextUnsavedIds)
+    }
   }, [shouldShowPrompt])
 }
 
@@ -30,7 +34,6 @@ export const promptUnsavedChangesOnClickEvent = (unsavedFormIdsState) => (
   clickEvent: React.MouseEvent
 ) => {
   let [unsavedFormIds, setUnsavedFormIds] = unsavedFormIdsState
-
   if (unsavedFormIds.length > 0) {
     if (window.confirm(DEFAULT_MESSAGE)) {
       setUnsavedFormIds([])


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/208

Prompt bugs that are fixed here:

1) Insert a new procurementUnit list -> prompts if leaving page
2) Go and create a new contract -> save -> prompts if leaving page
3) Inspection name change -> doesn't prompt if unsaved changes

(didn't find any other prompt issuses while testing - now everything seem to work!)

NOTE: when creating new inspection, it prompts about unsaved changes if trying to leave. That is due to name being dirty when it shouldnt be. It will be fixed in my date dropdown PR! So dont mind about that