### PR TITLE
198 Ability to lock user in HSL ID

### DIFF
--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -5,6 +5,7 @@
   "validityPeriod": "Voimassaoloaika",
   "login": "Kirjaudu sisään",
   "logout": "Kirjaudu ulos",
+  "login_failed": "Kirjautuminen epäonnistui. Ole yhteydessä HSL:n suuntaan ongelman jatkuessa.",
   "update": "Päivitä",
   "edit": "Muokkaa",
   "preview": "Esikatsele",

--- a/src/util/useAuth.ts
+++ b/src/util/useAuth.ts
@@ -121,5 +121,5 @@ export const useAuth = (): [AuthState, boolean] => {
     }
   }, [currentUser, codeUrlParam, authState, login, refetchUser, navigateNext])
 
-  return [authState, isLoggingLoading]
+  return [authState, isLoginLoading]
 }

--- a/src/util/useAuth.ts
+++ b/src/util/useAuth.ts
@@ -23,7 +23,7 @@ export const useAuth = (): [AuthState, boolean] => {
   // To prevent unwanted navigation, only set this to true when the app should
   // navigate away from the login screen.
   let shouldNavigate = useRef(false)
-  const [login, { loading: isLoggingLoading }] = useMutationData<User>(loginMutation)
+  const [login, { loading: isLoginLoading }] = useMutationData<User>(loginMutation)
   const {
     data: fetchedUser,
     refetch: refetchUserCb,

--- a/src/util/useAuth.ts
+++ b/src/util/useAuth.ts
@@ -23,8 +23,7 @@ export const useAuth = (): [AuthState, boolean] => {
   // To prevent unwanted navigation, only set this to true when the app should
   // navigate away from the login screen.
   let shouldNavigate = useRef(false)
-  const [login, { loading: isLogingLoading }] = useMutationData<User>(loginMutation)
-  const [isLoginFailed, setIsLoginFailed] = useState<boolean>(false)
+  const [login, { loading: isLoggingLoading }] = useMutationData<User>(loginMutation)
   const {
     data: fetchedUser,
     refetch: refetchUserCb,
@@ -47,12 +46,8 @@ export const useAuth = (): [AuthState, boolean] => {
     }
     if (fetchedUser) {
       setCurrentUser(fetchedUser)
-    } else {
-      if (isLoginFailed) {
-        setErrorMessage(text('login_failed'))
-      }
     }
-  }, [fetchedUser, isCurrentUserLoading, currentUser, isLoginFailed])
+  }, [fetchedUser, isCurrentUserLoading, currentUser])
 
   useEffect(() => {
     if (getAuthToken() && !currentUser && !fetchedUser && !isCurrentUserLoading) {
@@ -120,11 +115,11 @@ export const useAuth = (): [AuthState, boolean] => {
           refetchUser()
         } else {
           setAuthState(AuthState.UNAUTHENTICATED)
-          setIsLoginFailed(true)
+          setErrorMessage(text('login_failed'))
         }
       })
     }
   }, [currentUser, codeUrlParam, authState, login, refetchUser, navigateNext])
 
-  return [authState, isLogingLoading]
+  return [authState, isLoggingLoading]
 }

--- a/src/util/useAuth.ts
+++ b/src/util/useAuth.ts
@@ -24,7 +24,7 @@ export const useAuth = (): [AuthState, boolean] => {
   // navigate away from the login screen.
   let shouldNavigate = useRef(false)
   const [login, { loading: isLogingLoading }] = useMutationData<User>(loginMutation)
-  const [isLoggingIn, setIsLoggingIn] = useState<boolean>(false)
+  const [isLoginFailed, setIsLoginFailed] = useState<boolean>(false)
   const {
     data: fetchedUser,
     refetch: refetchUserCb,
@@ -48,11 +48,11 @@ export const useAuth = (): [AuthState, boolean] => {
     if (fetchedUser) {
       setCurrentUser(fetchedUser)
     } else {
-      if (!isLoggingIn) {
+      if (isLoginFailed) {
         setErrorMessage(text('login_failed'))
       }
     }
-  }, [fetchedUser, isCurrentUserLoading, currentUser, isLoggingIn])
+  }, [fetchedUser, isCurrentUserLoading, currentUser, isLoginFailed])
 
   useEffect(() => {
     if (getAuthToken() && !currentUser && !fetchedUser && !isCurrentUserLoading) {
@@ -100,7 +100,6 @@ export const useAuth = (): [AuthState, boolean] => {
     }
 
     if (codeUrlParam && authState === AuthState.UNAUTHENTICATED) {
-      setIsLoggingIn(true)
       setAuthState(AuthState.PENDING)
       setUrlValue('code', null)
       setUrlValue('isTest', null)
@@ -121,8 +120,8 @@ export const useAuth = (): [AuthState, boolean] => {
           refetchUser()
         } else {
           setAuthState(AuthState.UNAUTHENTICATED)
+          setIsLoginFailed(true)
         }
-        setIsLoggingIn(false)
       })
     }
   }, [currentUser, codeUrlParam, authState, login, refetchUser, navigateNext])


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/198

* Steps for thesting can be found from the issue description.

* when user is logged and then blocked from HSL ID, he can still do things like saving (until he presses f5)
   * there is nothing we can do about this (or we could fetch groups from HSL ID with every request but that's not what we want to do)
   * BUT if you make user.role = 'BLOCKED' by hand in DB, then saving should be prevented -> test that this works (works for me at least)
 
* when user is blocked, it gives 400 (Bad Request) and that seems to crash the app. Maybe not in scope of this task to fix it but maybe it should be fixed somewhere (or here)?

* Note: from now on, user must be 'blocked' in HSL ID (if making it only 'blocked' in DB, it will be overridden when the user logins if he is not in 'blocked group')
