### PR TITLE
230 prevent season switch when opening inspection

### DIFF
--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -117,7 +117,7 @@ export const SidebarStyledSelect = styled(Dropdown)`
   }
 
   > div {
-    padding: 0 1rem 1rem;
+    padding: 0 1rem 0.5rem 1rem;
 
     > button {
       border: 1px solid var(--dark-blue);
@@ -140,6 +140,12 @@ export const SidebarStyledSelect = styled(Dropdown)`
       color: white;
       font-size: 1rem;
     }
+  }
+`
+
+export const SidebarSeasonFilter = styled(SidebarStyledSelect)`
+  > div {
+    padding-bottom: 0;
   }
 `
 

--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -19,7 +19,6 @@ import { useMutationData } from '../../util/useMutationData'
 import { pickGraphqlData } from '../../util/pickGraphqlData'
 import { removeAuthToken } from '../../util/authToken'
 import { navigateWithQueryString } from '../../util/urlValue'
-import Dropdown from '../input/Dropdown'
 import { promptUnsavedChangesOnClickEvent } from '../../util/promptUnsavedChanges'
 import { DEBUG } from '../../constants'
 import { useHasAdminAccessRights } from '../../util/userRoles'
@@ -103,51 +102,6 @@ const UserLink = styled(Link)`
 `
 
 const GlobalFilters = styled.div``
-
-export const SidebarStyledSelect = styled(Dropdown)`
-  > label {
-    padding-left: 1rem;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--dark-blue);
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    color: #eeeeee;
-  }
-
-  > div {
-    padding: 0 1rem 0.5rem 1rem;
-
-    > button {
-      border: 1px solid var(--dark-blue);
-      &:hover {
-        background: var(--lighter-grey);
-        transition: 0s;
-        > svg * {
-          fill: var(--dark-grey);
-        }
-      }
-    }
-  }
-
-  ul {
-    left: 1rem;
-    width: calc(100% - 2rem);
-    background: var(--dark-grey);
-    border: 1px solid var(--dark-blue);
-    > li {
-      color: white;
-      font-size: 1rem;
-    }
-  }
-`
-
-export const SidebarSeasonFilter = styled(SidebarStyledSelect)`
-  > div {
-    padding-bottom: 0;
-  }
-`
 
 const clearCacheMutation = gql`
   mutation clearCache {

--- a/src/common/components/GlobalOperatorFilter.tsx
+++ b/src/common/components/GlobalOperatorFilter.tsx
@@ -4,8 +4,8 @@ import { useStateValue } from '../../state/useAppState'
 import SelectOperator from '../input/SelectOperator'
 import { UserRole } from '../../schema-types'
 import { getUrlValue } from '../../util/urlValue'
-import { SidebarStyledSelect } from './AppSidebar'
 import { useLocation } from '@reach/router'
+import { SidebarStyledDropdown } from './SidebarStyledDropdown'
 
 const GlobalOperatorFilter: React.FC = observer(() => {
   var [operator, setOperatorFilter] = useStateValue('globalOperator')
@@ -20,7 +20,7 @@ const GlobalOperatorFilter: React.FC = observer(() => {
   var userIsOperator = user && user?.role === UserRole.Operator
 
   return (
-    <SidebarStyledSelect
+    <SidebarStyledDropdown
       as={SelectOperator}
       onSelect={setOperatorFilter}
       value={operator}

--- a/src/common/components/GlobalSeasonFilter.tsx
+++ b/src/common/components/GlobalSeasonFilter.tsx
@@ -1,12 +1,21 @@
 import React, { useMemo } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useStateValue } from '../../state/useAppState'
-import { SidebarStyledSelect } from './AppSidebar'
+import { SidebarSeasonFilter } from './AppSidebar'
 import SelectSeason from '../input/SelectSeason'
 import { getUrlValue } from '../../util/urlValue'
+import { getReadableDateRange } from '../../util/formatDate'
+import styled from 'styled-components/macro'
+import { text } from '../../util/translate'
+import { Season } from '../../schema-types'
+
+const SeasonTimeSpan = styled.div`
+  font-size: 0.8rem;
+  margin-left: 1rem;
+`
 
 const GlobalSeasonFilter: React.FC = observer(() => {
-  const [season, setSeasonFilter] = useStateValue('globalSeason')
+  const [season, setSeasonFilter] = useStateValue<Season>('globalSeason')
 
   let initialSeasonId: string | undefined = useMemo(() => {
     let initialVal = (getUrlValue('season') || '') + ''
@@ -14,13 +23,20 @@ const GlobalSeasonFilter: React.FC = observer(() => {
   }, [])
 
   return (
-    <SidebarStyledSelect
-      as={SelectSeason}
-      onSelect={setSeasonFilter}
-      value={season}
-      label="Valitse kausi"
-      selectInitialId={initialSeasonId}
-    />
+    <React.Fragment>
+      <SidebarSeasonFilter
+        as={SelectSeason}
+        onSelect={setSeasonFilter}
+        value={season}
+        label={text('selectSeason')}
+        selectInitialId={initialSeasonId}
+      />
+      {season && (
+        <SeasonTimeSpan>
+          {getReadableDateRange({ start: season.startDate, end: season.endDate })}
+        </SeasonTimeSpan>
+      )}
+    </React.Fragment>
   )
 })
 

--- a/src/common/components/GlobalSeasonFilter.tsx
+++ b/src/common/components/GlobalSeasonFilter.tsx
@@ -10,6 +10,7 @@ import { text } from '../../util/translate'
 import { Season } from '../../schema-types'
 
 const SeasonTimeSpan = styled.div`
+  padding-top: 0.2rem;
   font-size: 0.8rem;
   margin-left: 1rem;
 `

--- a/src/common/components/GlobalSeasonFilter.tsx
+++ b/src/common/components/GlobalSeasonFilter.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useStateValue } from '../../state/useAppState'
-import { SidebarSeasonFilter } from './AppSidebar'
 import SelectSeason from '../input/SelectSeason'
 import { getUrlValue } from '../../util/urlValue'
 import { getReadableDateRange } from '../../util/formatDate'
 import styled from 'styled-components/macro'
 import { text } from '../../util/translate'
 import { Season } from '../../schema-types'
+import { SidebarStyledDropdown } from './SidebarStyledDropdown'
 
 const SeasonTimeSpan = styled.div`
   padding-top: 0.2rem;
@@ -25,7 +25,7 @@ const GlobalSeasonFilter: React.FC = observer(() => {
 
   return (
     <React.Fragment>
-      <SidebarSeasonFilter
+      <SidebarStyledDropdown
         as={SelectSeason}
         onSelect={setSeasonFilter}
         value={season}

--- a/src/common/components/SidebarStyledDropdown.tsx
+++ b/src/common/components/SidebarStyledDropdown.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components/macro'
+import Dropdown from '../input/Dropdown'
+
+export const SidebarStyledDropdown = styled(Dropdown)`
+  > label {
+    padding-left: 1rem;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--dark-blue);
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    color: #eeeeee;
+  }
+
+  > div {
+    padding: 0 1rem;
+
+    > button {
+      border: 1px solid var(--dark-blue);
+      &:hover {
+        background: var(--lighter-grey);
+        transition: 0s;
+        > svg * {
+          fill: var(--dark-grey);
+        }
+      }
+    }
+  }
+
+  ul {
+    left: 1rem;
+    width: calc(100% - 2rem);
+    background: var(--dark-grey);
+    border: 1px solid var(--dark-blue);
+
+    > li {
+      color: white;
+      font-size: 1rem;
+    }
+  }
+`

--- a/src/inspection/InspectionActions.tsx
+++ b/src/inspection/InspectionActions.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite'
 import { Inspection, InspectionStatus, InspectionType, Season } from '../schema-types'
 import { Button, ButtonSize, ButtonStyle } from '../common/components/buttons/Button'
 import {
-  useEditInspection,
+  useNavigateToInspection,
   useNavigateToInspectionReports,
   useRemoveInspection,
 } from './inspectionUtils'
@@ -61,21 +61,16 @@ const InspectionActions = observer(
 
     var isEditing: boolean = Boolean(useMatch(`/:inspectionType/edit/:inspectionId/*`))
 
-    var goToInspectionEdit = useEditInspection(inspection.inspectionType)
+    var navigateToInspection = useNavigateToInspection(inspection.inspectionType)
     var goToInspectionReports = useNavigateToInspectionReports()
 
     var hasErrors = inspection?.inspectionErrors?.length !== 0
 
-    var onEditInspection = useCallback(
+    var onOpenInspection = useCallback(
       (inspection: Inspection) => {
-        // If the season of the inspection is not already selected, ensure it is selected.
-        if (inspection.seasonId !== season.id) {
-          setSeason(inspection.season)
-        }
-
-        goToInspectionEdit(inspection)
+        navigateToInspection(inspection)
       },
-      [goToInspectionEdit, setSeason, season]
+      [navigateToInspection, setSeason, season]
     )
 
     var [removeInspection, { loading: removeLoading }] = useRemoveInspection(
@@ -196,7 +191,7 @@ const InspectionActions = observer(
             <Button
               buttonStyle={ButtonStyle.NORMAL}
               size={ButtonSize.MEDIUM}
-              onClick={() => onEditInspection(inspection)}>
+              onClick={() => onOpenInspection(inspection)}>
               {inspection.status === InspectionStatus.Draft ? 'Muokkaa' : 'Avaa'}
             </Button>
           )}

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -103,6 +103,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection
           <FlexRow>
             <InspectionSelectDates
               inspectionType={inspection.inspectionType}
+              inspectionSeason={inspection.season}
               isEditingDisabled={inspection.status !== InspectionStatus.Draft}
               inspectionInput={pendingInspectionInputValues}
               onChange={onChangeInspectionDate}

--- a/src/inspection/InspectionEditor.tsx
+++ b/src/inspection/InspectionEditor.tsx
@@ -19,6 +19,7 @@ import PostInspectionEditor from '../postInspection/PostInspectionEditor'
 import PreInspectionEditor from '../preInspection/PreInspectionEditor'
 import InspectionValidationErrors from './InspectionValidationErrors'
 import { Button } from '../common/components/buttons/Button'
+import { getInspectionTypeStrings } from './inspectionUtils'
 
 const EditInspectionView = styled.div`
   width: 100%;
@@ -81,8 +82,10 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
         return
       }
 
-      if (inspection.operatorId !== operator.operatorId) {
-        navigateWithQueryString(`/pre-inspection/edit`)
+      if (inspection.operatorId !== operator.operatorId || inspection.seasonId !== season.id) {
+        navigateWithQueryString(
+          `/${getInspectionTypeStrings(inspection.inspectionType).prefixLC}-inspection/edit`
+        )
       }
     }, [inspection, operator, season])
 

--- a/src/inspection/InspectionEditor.tsx
+++ b/src/inspection/InspectionEditor.tsx
@@ -81,7 +81,7 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
         return
       }
 
-      if (inspection.operatorId !== operator.operatorId || inspection.seasonId !== season.id) {
+      if (inspection.operatorId !== operator.operatorId) {
         navigateWithQueryString(`/pre-inspection/edit`)
       }
     }, [inspection, operator, season])

--- a/src/inspection/SelectInspection.tsx
+++ b/src/inspection/SelectInspection.tsx
@@ -10,7 +10,7 @@ import {
   getInspectionStatusName,
   getInspectionTypeStrings,
   useCreateInspection,
-  useEditInspection,
+  useNavigateToInspection,
 } from './inspectionUtils'
 import { MessageContainer, MessageView } from '../common/components/Messages'
 import { SubHeading } from '../common/components/Typography'
@@ -177,7 +177,7 @@ const SelectInspection: React.FC<PropTypes> = observer(
     var [season] = useStateValue('globalSeason')
     var [operator] = useStateValue('globalOperator')
 
-    var editInspection = useEditInspection(inspectionType)
+    var navigateToInspection = useNavigateToInspection(inspectionType)
 
     // Initialize the form by creating a pre-inspection on the server and getting the ID.
     let createInspection = useCreateInspection(operator, season, inspectionType)
@@ -186,11 +186,11 @@ const SelectInspection: React.FC<PropTypes> = observer(
       let createdInspection = await createInspection()
 
       if (createdInspection) {
-        editInspection(createdInspection)
+        navigateToInspection(createdInspection)
       }
 
       await refetchInspections()
-    }, [createInspection, refetchInspections, editInspection])
+    }, [createInspection, refetchInspections, navigateToInspection])
 
     let typeStrings = getInspectionTypeStrings(inspectionType)
 

--- a/src/inspection/inspectionSelectDates.tsx
+++ b/src/inspection/inspectionSelectDates.tsx
@@ -17,7 +17,6 @@ import { text } from '../util/translate'
 import { useQueryData } from '../util/useQueryData'
 import { getHfpStatusColor, HfpStatusIndicator } from '../common/components/HfpStatus'
 import { lowerCase, orderBy } from 'lodash'
-import { useStateValue } from '../state/useAppState'
 
 const InspectionSelectDatesView = styled.div`
   margin: 1rem 0;
@@ -43,20 +42,25 @@ interface DateOption {
 export type PropTypes = {
   isEditingDisabled: boolean
   inspectionType: InspectionType
+  inspectionSeason: Season
   inspectionInput: InspectionInput
   onChange: (startDate: Date, endDate: Date, id?: string) => void
 }
 
 const InspectionSelectDates = observer(
-  ({ isEditingDisabled, inspectionType, inspectionInput, onChange }: PropTypes) => {
-    let [season] = useStateValue<Season>('globalSeason')
-
+  ({
+    isEditingDisabled,
+    inspectionType,
+    inspectionSeason,
+    inspectionInput,
+    onChange,
+  }: PropTypes) => {
     let {
       data: inspectionDatesQueryResult,
       loading: areInspectionDatesLoading,
     } = useQueryData<InspectionDate[]>(getObservedInspectionDatesQuery, {
       variables: {
-        seasonId: season.id,
+        seasonId: inspectionSeason.id,
       },
       skip: inspectionType === InspectionType.Pre,
     })
@@ -65,7 +69,7 @@ const InspectionSelectDates = observer(
       let opts: DateOption[] = []
 
       if (inspectionType === InspectionType.Pre) {
-        opts = getPreInspectionDateOptions(season)
+        opts = getPreInspectionDateOptions(inspectionSeason)
       } else {
         opts = inspectionDatesQueryResult
           ? getPostInspectionDateOptions(inspectionDatesQueryResult)

--- a/src/inspection/inspectionUtils.ts
+++ b/src/inspection/inspectionUtils.ts
@@ -122,7 +122,7 @@ export function useRemoveInspection(
 export function useNavigateToInspection(inspectionType: InspectionType = InspectionType.Pre) {
   return useCallback(
     (inspection?: Inspection) => {
-      let pathSegment = inspectionType === InspectionType.Pre ? 'pre' : 'post'
+      let pathSegment = getInspectionTypeStrings(inspectionType).prefixLC
 
       if (inspection) {
         return navigateWithQueryString(`/${pathSegment}-inspection/edit/${inspection.id}`)

--- a/src/inspection/inspectionUtils.ts
+++ b/src/inspection/inspectionUtils.ts
@@ -119,7 +119,7 @@ export function useRemoveInspection(
   return [execRemove, { loading }]
 }
 
-export function useEditInspection(inspectionType: InspectionType = InspectionType.Pre) {
+export function useNavigateToInspection(inspectionType: InspectionType = InspectionType.Pre) {
   return useCallback(
     (inspection?: Inspection) => {
       let pathSegment = inspectionType === InspectionType.Pre ? 'pre' : 'post'

--- a/src/page/EditInspectionPage.tsx
+++ b/src/page/EditInspectionPage.tsx
@@ -12,7 +12,7 @@ import {
   getInspectionStatusColor,
   getInspectionStatusName,
   getInspectionTypeStrings,
-  useEditInspection,
+  useNavigateToInspection,
   useInspectionById,
 } from '../inspection/inspectionUtils'
 import { MessageContainer, MessageView } from '../common/components/Messages'
@@ -85,7 +85,7 @@ const EditInspectionPage: React.FC<PropTypes> = observer(
     var [season] = useStateValue('globalSeason')
     var [operator] = useStateValue('globalOperator')
     var [, setErrorMessage] = useStateValue('errorMessage')
-    var editInspection = useEditInspection(inspectionType)
+    var navigateToInspection = useNavigateToInspection(inspectionType)
 
     let { data: inspection, loading: inspectionLoading, refetch } = useInspectionById(
       inspectionId
@@ -150,7 +150,7 @@ const EditInspectionPage: React.FC<PropTypes> = observer(
             ) : !inspection && !inspectionLoading ? (
               <MessageContainer style={{ margin: '1rem' }}>
                 <MessageView>Haettu {typeStrings.prefixLC}tarkastus ei löytynyt.</MessageView>
-                <Button onClick={() => editInspection()}>
+                <Button onClick={() => navigateToInspection()}>
                   <Text>back</Text>
                 </Button>
               </MessageContainer>

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -6,6 +6,7 @@
   "login": "Kirjaudu sisään",
   "logout": "Kirjaudu ulos",
   "login_failed": "Kirjautuminen epäonnistui. Ole yhteydessä HSL:n suuntaan ongelman jatkuessa.",
+  "selectSeason": "Valitse kausi",
   "update": "Päivitä",
   "edit": "Muokkaa",
   "preview": "Esikatsele",


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/230

As a small bonus, added inspection date range (we've had discussion that it's ok to do):

Tried to override the style at: GlobalSeasonFilter.tsx
with:
const StyledDropdown = styled(SidebarStyledSelect)`
  padding-bottom: 0;
`

but got this error:
ReferenceError: Cannot access 'SidebarStyledSelect' before initialization
so that's why I made a separate styled element in AppSidebar
