### PR TITLE
216 use thousand separator in tables

### DIFF
--- a/src/common/table/tableUtils.tsx
+++ b/src/common/table/tableUtils.tsx
@@ -6,6 +6,7 @@ import { READABLE_TIME_FORMAT } from '../../constants'
 import { toString } from 'lodash'
 import { TableInput, TablePropTypes, TableTextInput } from './Table'
 import { CellContent } from './TableCell'
+import { getThousandSeparatedNumber } from '../../util/formatNumber'
 
 export type FilteredResponseMeta = {
   filteredCount?: number
@@ -37,12 +38,11 @@ export function useRenderCellValue() {
     }
 
     if (typeof val === 'number') {
-      return round(val)
+      return getThousandSeparatedNumber(round(val))
     }
 
     if (val.length >= 20) {
       let date: Date | undefined
-
       try {
         let parsedDate = parseISO(val)
 

--- a/src/executionRequirement/ObservedRequirementsTable.tsx
+++ b/src/executionRequirement/ObservedRequirementsTable.tsx
@@ -13,6 +13,7 @@ import { getTotal } from '../util/getTotal'
 import { round } from '../util/round'
 import { EditValue, TableEditProps } from '../common/table/tableUtils'
 import { DEFAULT_DECIMALS } from '../constants'
+import { getThousandSeparatedNumber } from '../util/formatNumber'
 
 const ExecutionRequirementsAreaContainer = styled.div`
   margin-top: 1.5rem;
@@ -100,7 +101,7 @@ const ObservedRequirementsTable: React.FC<PropTypes> = observer(
           unit = ''
       }
 
-      return `${round(val, 6)} ${unit}`
+      return `${getThousandSeparatedNumber(round(val, 6))} ${unit}`
     }, [])
 
     let getColumnTotal = useCallback(
@@ -116,7 +117,9 @@ const ObservedRequirementsTable: React.FC<PropTypes> = observer(
           return ''
         }
 
-        let totalValue = round(getTotal<any, string>(requirementRows, key), DEFAULT_DECIMALS)
+        let totalValue = getThousandSeparatedNumber(
+          round(getTotal<any, string>(requirementRows, key), DEFAULT_DECIMALS)
+        )
         switch (key) {
           case 'quotaRequired':
           case 'quotaObserved':

--- a/src/executionRequirement/RequirementsTable.tsx
+++ b/src/executionRequirement/RequirementsTable.tsx
@@ -149,6 +149,7 @@ const RequirementsTable: React.FC<PropTypes> = observer(
         let totalVal = getThousandSeparatedNumber(
           round(getTotal<any, string>(requirementRows, key), DEFAULT_DECIMALS)
         )
+
         switch (key) {
           case 'percentage':
           case 'quotaRequirement':

--- a/src/executionRequirement/RequirementsTable.tsx
+++ b/src/executionRequirement/RequirementsTable.tsx
@@ -15,6 +15,7 @@ import {
 import Big from 'big.js'
 import { text } from '../util/translate'
 import { DEFAULT_DECIMALS } from '../constants'
+import { getThousandSeparatedNumber } from '../util/formatNumber'
 
 const ExecutionRequirementsAreaContainer = styled.div`
   margin-top: 1rem;
@@ -135,7 +136,7 @@ const RequirementsTable: React.FC<PropTypes> = observer(
           unit = ''
       }
 
-      let useVal = round(val)
+      let useVal = getThousandSeparatedNumber(round(val))
       return `${useVal} ${unit}`
     }, [])
 
@@ -145,7 +146,9 @@ const RequirementsTable: React.FC<PropTypes> = observer(
           return ''
         }
 
-        let totalVal = round(getTotal<any, string>(requirementRows, key), DEFAULT_DECIMALS)
+        let totalVal = getThousandSeparatedNumber(
+          round(getTotal<any, string>(requirementRows, key), DEFAULT_DECIMALS)
+        )
         switch (key) {
           case 'percentage':
           case 'quotaRequirement':

--- a/src/report/reportTotals.ts
+++ b/src/report/reportTotals.ts
@@ -4,6 +4,10 @@ import { getTotal } from '../util/getTotal'
 import { round } from '../util/round'
 import Big from 'big.js'
 import { text } from '../util/translate'
+import {
+  getThousandSeparatedNumber,
+  getThousandSeparatedNumberBig,
+} from '../util/formatNumber'
 
 // Define column total functions here with the name of the report they apply to.
 const reportTotalFns = {
@@ -31,12 +35,16 @@ function createSanctionSummaryColumnTotals(rows: SanctionSummaryReportData[]) {
   return (key: keyof SanctionSummaryReportData) => {
     // Show the total kilometers sanctioned by this sanction
     if (key.endsWith('KM')) {
-      return round(getTotal(rows, key), 6) + ' KM'
+      return getThousandSeparatedNumber(round(getTotal(rows, key), 6)) + ' KM'
     }
 
     // Show how many percentage of all sanctions this sanction column accounts for
     if (key.endsWith('%')) {
-      return Big(getTotal(rows, key)).div(Math.max(rows.length, 1)).round(6).mul(100) + '%'
+      return (
+        getThousandSeparatedNumberBig(
+          Big(getTotal(rows, key)).div(Math.max(rows.length, 1)).round(6).mul(100)
+        ) + '%'
+      )
     }
 
     return ''
@@ -49,6 +57,6 @@ function createEmissionClassExecutionColumnTotals(rows: EmissionClassExecutionRe
       return text('table_totalCount')
     }
     // Show the total kilometers of this emission class
-    return round(getTotal(rows, key), 0) + ' km'
+    return getThousandSeparatedNumber(round(getTotal(rows, key), 0)) + ' km'
   }
 }

--- a/src/report/reportTotals.ts
+++ b/src/report/reportTotals.ts
@@ -4,10 +4,7 @@ import { getTotal } from '../util/getTotal'
 import { round } from '../util/round'
 import Big from 'big.js'
 import { text } from '../util/translate'
-import {
-  getThousandSeparatedNumber,
-  getThousandSeparatedNumberBig,
-} from '../util/formatNumber'
+import { getThousandSeparatedNumber } from '../util/formatNumber'
 
 // Define column total functions here with the name of the report they apply to.
 const reportTotalFns = {
@@ -41,7 +38,7 @@ function createSanctionSummaryColumnTotals(rows: SanctionSummaryReportData[]) {
     // Show how many percentage of all sanctions this sanction column accounts for
     if (key.endsWith('%')) {
       return (
-        getThousandSeparatedNumberBig(
+        getThousandSeparatedNumber(
           Big(getTotal(rows, key)).div(Math.max(rows.length, 1)).round(6).mul(100)
         ) + '%'
       )

--- a/src/util/formatNumber.ts
+++ b/src/util/formatNumber.ts
@@ -1,5 +1,11 @@
+import Big from 'big.js'
+
 export const getThousandSeparatedNumber = (input: number | string): string => {
   let numberInput = typeof input === 'string' ? parseFloat(input) : input
 
   return numberInput.toLocaleString().replace(',', ' ')
+}
+
+export const getThousandSeparatedNumberBig = (input: Big): string => {
+  return getThousandSeparatedNumber(input.toFixed())
 }

--- a/src/util/formatNumber.ts
+++ b/src/util/formatNumber.ts
@@ -1,11 +1,5 @@
 import Big from 'big.js'
 
-export const getThousandSeparatedNumber = (input: number | string): string => {
-  let numberInput = typeof input === 'string' ? parseFloat(input) : input
-
-  return numberInput.toLocaleString().replace(',', ' ')
-}
-
-export const getThousandSeparatedNumberBig = (input: Big): string => {
-  return getThousandSeparatedNumber(input.toFixed())
+export function getThousandSeparatedNumber(input: Big | number | string): string {
+  return Big(input).toNumber().toLocaleString().replace(',', ' ')
 }

--- a/src/util/formatNumber.ts
+++ b/src/util/formatNumber.ts
@@ -1,0 +1,5 @@
+export const getThousandSeparatedNumber = (input: number | string): string => {
+  let numberInput = typeof input === 'string' ? parseFloat(input) : input
+
+  return numberInput.toLocaleString().replace(',', ' ')
+}


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/216

I'd prefer to just make one util: getThousandSeparatedNumber() to handle all 3 input types: input: number | string | Big

but to implement that, you have to check if input type is Big, but how to do that? This didn't work: typeof input === 'Big'
