### PR TITLE
Review fixes, getRowHighlightColor + getCellHighlightColor now work

### DIFF
--- a/src/common/table/FilteredResponseTable.tsx
+++ b/src/common/table/FilteredResponseTable.tsx
@@ -31,7 +31,7 @@ export type PropTypes<ItemType extends TableItemType> = {
   loading?: boolean
   groupBy?: (item: ItemType) => string
   transformItems?: (items: ItemType[]) => ItemType[]
-  cellHighlighter?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => boolean
+  getCellHighlightColor?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => string
 } & Omit<TablePropTypes<ItemType>, 'items'>
 
 const FilteredResponseTable = observer(
@@ -42,7 +42,7 @@ const FilteredResponseTable = observer(
     tableState,
     groupBy: groupByFn,
     transformItems = (items) => items,
-    cellHighlighter,
+    getCellHighlightColor,
     ...tableProps
   }: PropTypes<ItemType>) => {
     let { filters = [], sort = [], setFilters = () => {}, setSort = () => {} } = tableState
@@ -96,7 +96,7 @@ const FilteredResponseTable = observer(
               sort={sort}
               setSort={setSort}
               columnLabels={existingPropLabels}
-              cellHighlighter={cellHighlighter}>
+              getCellHighlightColor={getCellHighlightColor}>
               <TableEmptyView>
                 <Text>tableEmpty</Text>
               </TableEmptyView>

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -7,7 +7,8 @@ import { useWatchDirtyForm } from '../../util/promptUnsavedChanges'
 import { SortConfig, SortOrder } from '../../schema-types'
 import {
   ContextTypes,
-  defaultHighlightRow,
+  defaultGetCellHighlightColor,
+  defaultGetRowHighlightColor,
   defaultKeyFromItem,
   defaultRenderCellContent,
   defaultRenderInput,
@@ -106,8 +107,8 @@ export type TablePropTypes<ItemType extends TableItemType> = {
     item?: ItemType
   ) => React.ReactNode
   getColumnTotal?: (key: string) => React.ReactChild
-  highlightRow?: (item: ItemType) => boolean | string
-  cellHighlighter?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => boolean
+  getRowHighlightColor?: (item: TableRowWithDataAndFunctions<ItemType>) => string
+  getCellHighlightColor?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => string
   renderInput?: RenderInputType<ItemType>
   maxHeight?: number
   showToolbar?: boolean // Show toolbar when there are editable values and a save function
@@ -138,8 +139,8 @@ const Table = observer(
     renderInput = defaultRenderInput,
     editableValues = [],
     showToolbar = true,
-    highlightRow = defaultHighlightRow,
-    cellHighlighter,
+    getRowHighlightColor = defaultGetRowHighlightColor,
+    getCellHighlightColor = defaultGetCellHighlightColor,
     children: emptyContent,
     sort: propSort,
     setSort: propSetSort,
@@ -196,7 +197,6 @@ const Table = observer(
       renderInput,
       renderValue,
       keyFromItem,
-      highlightRow,
       isAlwaysEditable,
     }
 
@@ -280,7 +280,8 @@ const Table = observer(
                     key={row.key || rowIndex}
                     row={row}
                     index={rowIndex}
-                    cellHighlighter={cellHighlighter}
+                    getRowHighlightColor={getRowHighlightColor}
+                    getCellHighlightColor={getCellHighlightColor}
                   />
                 ))}
             {typeof getColumnTotal === 'function' && (

--- a/src/common/table/TableCell.tsx
+++ b/src/common/table/TableCell.tsx
@@ -26,9 +26,7 @@ export const TableCellElement = styled.div<{
   justify-content: center;
   font-size: 0.875rem;
   background: ${(p) =>
-    p.isEditing
-      ? 'var(--lightest-blue)'
-      : `var(${p.highlightColor})` || 'rgba(0, 0, 0, 0.005)'};
+    p.isEditing ? 'var(--lightest-blue)' : `${p.highlightColor}` || 'rgba(0, 0, 0, 0.005)'};
   position: relative;
   cursor: ${(p) => (p.editable ? 'pointer' : 'default')};
   overflow: hidden;
@@ -88,7 +86,7 @@ type CellPropTypes<ItemType extends TableItemType> = {
   colIndex: number
   tabIndex?: number
   rowId: string
-  rowHighlightColor?: string
+  cellHighlightColor?: string
 }
 
 export const TableCell = observer(
@@ -97,7 +95,7 @@ export const TableCell = observer(
     cell,
     colIndex,
     tabIndex = 1,
-    rowHighlightColor = '',
+    cellHighlightColor = '',
   }: CellPropTypes<ItemType>) => {
     let {
       pendingValues = [],
@@ -159,7 +157,7 @@ export const TableCell = observer(
 
     return (
       <TableCellElement
-        highlightColor={rowHighlightColor}
+        highlightColor={cellHighlightColor}
         style={cellWidthStyle}
         isEditing={cellIsEditable}
         isEditingRow={isEditingRow}

--- a/src/common/table/TableRow.tsx
+++ b/src/common/table/TableRow.tsx
@@ -56,7 +56,8 @@ type RowPropTypes<ItemType extends TableItemType> = {
   data?: TableRowWithDataAndFunctions<ItemType>[]
   style?: CSSProperties
   isScrolling?: boolean
-  cellHighlighter?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => boolean
+  getRowHighlightColor: (item: TableRowWithDataAndFunctions<ItemType>) => string
+  getCellHighlightColor: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => string
 }
 
 export const TableRow = observer(
@@ -64,7 +65,8 @@ export const TableRow = observer(
     row,
     style,
     index,
-    cellHighlighter,
+    getRowHighlightColor,
+    getCellHighlightColor,
     data: allRows = [],
   }: RowPropTypes<ItemType>) => {
     let rowItem = row || allRows[index]
@@ -76,6 +78,8 @@ export const TableRow = observer(
     let { itemEntries = [], key: rowKey, isEditingRow, onRemoveRow } = rowItem
     let rowId = rowKey ?? `row-${index}`
 
+    let rowHighlightColor = getRowHighlightColor(rowItem)
+
     return (
       <TableRowElement key={rowId} isEditing={isEditingRow} style={style}>
         {itemEntries.map(([key, val], colIndex) => (
@@ -86,12 +90,10 @@ export const TableRow = observer(
             colIndex={colIndex}
             tabIndex={index * allRows.length + colIndex + 1}
             cell={[key as keyof ItemType, val]}
-            rowHighlightColor={
-              cellHighlighter
-                ? cellHighlighter(rowItem, key as string)
-                  ? '--yellow'
-                  : undefined
-                : undefined
+            cellHighlightColor={
+              rowHighlightColor !== ''
+                ? rowHighlightColor
+                : getCellHighlightColor(rowItem, key as string)
             }
           />
         ))}

--- a/src/common/table/tableUtils.tsx
+++ b/src/common/table/tableUtils.tsx
@@ -152,10 +152,12 @@ export type ContextTypes<ItemType extends TableItemType> = {
   renderCell?: TablePropTypes<ItemType>['renderCell']
   renderValue?: TablePropTypes<ItemType>['renderValue']
   keyFromItem?: TablePropTypes<ItemType>['keyFromItem']
-  highlightRow?: TablePropTypes<ItemType>['highlightRow']
+  getRowHighlightColor?: TablePropTypes<ItemType>['getRowHighlightColor']
   isAlwaysEditable?: TablePropTypes<ItemType>['isAlwaysEditable']
 }
 
 export const TableContext = React.createContext({})
 
-export const defaultHighlightRow = (): string | boolean => false
+export const defaultGetRowHighlightColor = (): string => ''
+
+export const defaultGetCellHighlightColor = (): string => ''

--- a/src/equipment/EquipmentList.tsx
+++ b/src/equipment/EquipmentList.tsx
@@ -195,7 +195,9 @@ const EquipmentList: React.FC<PropTypes> = observer(
             onCancelEdit={onCancelPendingValue}
             onSaveEdit={updateEquipment ? onSavePendingValue : undefined}
             editableValues={editableValues}
-            highlightRow={(item) => (item.requirementOnly ? '#fff4da' : false)}
+            getRowHighlightColor={(itemRow) =>
+              itemRow.item.requirementOnly ? 'var(--lightest-yellow)' : ''
+            }
             renderInput={(key, val, onChange, onAccept, onCancel) => (
               <EquipmentFormInput
                 fieldComponent={TableTextInput}

--- a/src/executionRequirement/PlannedExecutionStats.tsx
+++ b/src/executionRequirement/PlannedExecutionStats.tsx
@@ -79,8 +79,10 @@ const PlannedExecutionStats = observer(({ executionRequirement }: PropTypes) => 
             isResizeEnabled={false}
             items={dayTypeStats}
             columnLabels={statsTableLabels}
-            highlightRow={(row) =>
-              row.equipmentCount > requirementEquipmentCount ? 'var(--lighter-red)' : false
+            getRowHighlightColor={(itemRow) =>
+              itemRow.item.equipmentCount > requirementEquipmentCount
+                ? 'var(--lighter-red)'
+                : ''
             }
           />
         </TableWrapper>

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,7 @@
   --light-red: #fdb3ca;
   --lighter-red: #fff2f5;
   --yellow: #fed100;
+  --lightest-yellow: #fff4da;
   --dark-yellow: #d9a900;
   --darker-grey: #333333;
   --dark-grey: #555555;

--- a/src/report/ReportContainer.tsx
+++ b/src/report/ReportContainer.tsx
@@ -17,7 +17,7 @@ import ObservedExecutionRequirementsReport from './ObservedExecutionRequirements
 import FilteredResponseTable from '../common/table/FilteredResponseTable'
 import { hasReportTransform, transformReport } from './transformReports'
 import { createColumnTotalCallback } from './reportTotals'
-import { reportCellHighlightMap } from './reportCellHighlight'
+import { reportCellHighlightColorMap } from './reportCellHighlightColor'
 
 const ReportViewWrapper = styled.div`
   position: relative;
@@ -138,7 +138,7 @@ const ReportContainer = observer((props: PropTypes) => {
     [reportName, preparedReport]
   )
 
-  let cellHighlighter = reportCellHighlightMap[reportName]
+  let getCellHighlightColor = reportCellHighlightColorMap[reportName]
 
   return (
     <ReportViewWrapper>
@@ -172,7 +172,7 @@ const ReportContainer = observer((props: PropTypes) => {
           columnLabels={columnLabels}
           keyFromItem={reportKeyFromItem}
           getColumnTotal={calculateReportTotals}
-          cellHighlighter={cellHighlighter}
+          getCellHighlightColor={getCellHighlightColor}
         />
       )}
     </ReportViewWrapper>

--- a/src/report/reportCellHighlightColor.ts
+++ b/src/report/reportCellHighlightColor.ts
@@ -1,16 +1,16 @@
 import { TableRowWithDataAndFunctions } from '../common/table/tableUtils'
 import { SanctionSummaryReportData } from '../schema-types'
 
-export const reportCellHighlightMap = {
-  sanctionSummary: shouldHighlightSanctionSummaryReportCell,
+export const reportCellHighlightColorMap = {
+  sanctionSummary: getSanctionSummaryReportCellHighlightColor,
 }
 
-function shouldHighlightSanctionSummaryReportCell(
+function getSanctionSummaryReportCellHighlightColor(
   rowItem: TableRowWithDataAndFunctions<SanctionSummaryReportData>,
   key: string
-): boolean {
-  return (
-    key === 'averageAgeWeightedObserved' &&
+): string {
+  return key === 'averageAgeWeightedObserved' &&
     rowItem.item.averageAgeWeightedObserved > rowItem.item.unitEquipmentMaxAge
-  )
+    ? 'var(--yellow)'
+    : ''
 }


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/271

Review fixes left from earlier PR: https://github.com/HSLdevcom/bultti-ui/pull/91

Rowhighlight should work, if there is row highlight, it currently overrides cell highlight. Well it could be done vise versa... but at least for the current setup works.