### PR TITLE
333 role fixes according to role matrix

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -779,6 +779,7 @@ type Mutation {
   modifyContract(contractInput: ContractInput!, file: Upload, operatorId: Int!): Contract!
   modifyUser(userInput: UserInput!): User!
   publishInspection(inspectionId: String!): Inspection!
+  refreshEquipmentInCatalogue(catalogueId: String!): EquipmentCatalogue!
   refreshExecutionRequirementForProcurementUnit(executionRequirementId: String!): PlannedUnitExecutionRequirement
   rejectInspection(inspectionId: String!): Inspection!
   removeAllEquipmentFromCatalogue(catalogueId: String!): EquipmentCatalogue!
@@ -800,7 +801,6 @@ type Mutation {
   updateEquipmentCatalogue(catalogueId: String!, equipmentCatalogue: EquipmentCatalogueInput!): EquipmentCatalogue!
   updateEquipmentCatalogueQuota(quota: Float!, quotaId: String!): EquipmentCatalogueQuota!
   updateEquipmentDefectSanctions(sanctionUpdates: [EquipmentDefectSanctionUpdate!]!): [EquipmentDefectSanction!]!
-  updateEquipmentInCatalogue(catalogueId: String!): EquipmentCatalogue!
   updateEquipmentRequirementQuota(meters: Float, quota: Float, quotaId: String!): ExecutionRequirementQuota!
   updateInspection(inspection: InspectionInput!, inspectionId: String!): Inspection!
   updateLinkedInspection(inspectionId: String!): PostInspection!

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ const App: React.FC = observer(() => {
         />
         <Route component={EditContractPage} path="/contract/:contractId" />
         <Route component={ContractPage} path="/contract" />
-        <Route component={DevPage} path="/dev-tools" />
+        {hasAdminAccessRights && <Route component={DevPage} path="/dev-tools" />}
         <Route component={ProcurementUnitsPage} path="/procurement-units" />
       </Switch>
     </AppFrame>

--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -148,7 +148,7 @@ export type AppSidebarProps = {
 
 const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
   const [user, setUser] = useStateValue('user')
-  let hasAdminAccess = useHasAdminAccessRights()
+  let hasAdminAccessRights = useHasAdminAccessRights()
 
   let userContent = (
     <>
@@ -243,7 +243,7 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
               <Plus fill="white" width="1rem" height="1rem" />
               <Text>nav_newPostInspection</Text>
             </NavLink>
-            {hasAdminAccess && (
+            {hasAdminAccessRights && (
               <NavLink to="/inspection-date">
                 <Plus fill="white" width="1rem" height="1rem" />
                 <Text>nav_editInspectionDates</Text>
@@ -253,7 +253,7 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
               <Menu fill="white" width="1rem" height="1rem" />
               <Text>reports</Text>
             </NavLink>
-            {DEBUG && (
+            {hasAdminAccessRights && DEBUG && (
               <NavLink to="/dev-tools">
                 <div>Dev tools</div>
               </NavLink>

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -111,7 +111,7 @@ export type TablePropTypes<ItemType extends TableItemType> = {
   getCellHighlightColor?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => string
   renderInput?: RenderInputType<ItemType>
   maxHeight?: number
-  showToolbar?: boolean // Show toolbar when there are editable values and a save function
+  showToolbar?: boolean // Show toolbar when there are isCatalogueEditable values and a save function
   children?: React.ReactChild
   sort?: SortConfig[]
   setSort?: (arg: ((sort: SortConfig[]) => SortConfig[]) | SortConfig[]) => unknown

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -111,7 +111,7 @@ export type TablePropTypes<ItemType extends TableItemType> = {
   getCellHighlightColor?: (item: TableRowWithDataAndFunctions<ItemType>, key: string) => string
   renderInput?: RenderInputType<ItemType>
   maxHeight?: number
-  showToolbar?: boolean // Show toolbar when there are isCatalogueEditable values and a save function
+  showToolbar?: boolean // Show toolbar when there are editable values and a save function
   children?: React.ReactChild
   sort?: SortConfig[]
   setSort?: (arg: ((sort: SortConfig[]) => SortConfig[]) | SortConfig[]) => unknown

--- a/src/equipment/equipmentQuery.ts
+++ b/src/equipment/equipmentQuery.ts
@@ -100,9 +100,9 @@ export const addBatchEquipmentMutation = gql`
   ${EquipmentFragment}
 `
 
-export const updateCatalogueEquipmentDataMutation = gql`
-  mutation updateEquipmentInCatalogue($catalogueId: String!) {
-    updateEquipmentInCatalogue(catalogueId: $catalogueId) {
+export const refreshEquipmentInCatalogueMutation = gql`
+  mutation refreshEquipmentInCatalogue($catalogueId: String!) {
+    refreshEquipmentInCatalogue(catalogueId: $catalogueId) {
       id
       equipmentQuotas {
         id

--- a/src/equipmentCatalogue/CatalogueEquipmentList.tsx
+++ b/src/equipmentCatalogue/CatalogueEquipmentList.tsx
@@ -19,7 +19,7 @@ export type PropTypes = {
   operatorId: number
   startDate: Date
   onEquipmentChanged: () => unknown
-  equipmentEditable: boolean
+  isCatalogueEditable: boolean
 }
 
 export const equipmentColumnLabels = {
@@ -43,7 +43,7 @@ export const groupedEquipmentColumnLabels = {
 
 const CatalogueEquipmentList: React.FC<PropTypes> = observer(
   ({
-    equipmentEditable,
+    isCatalogueEditable,
     equipment,
     catalogueId,
     operatorId,
@@ -100,12 +100,12 @@ const CatalogueEquipmentList: React.FC<PropTypes> = observer(
       <>
         <EquipmentList
           equipment={equipment}
-          updateEquipment={equipmentEditable ? updateEquipment : undefined}
-          removeEquipment={equipmentEditable ? removeEquipment : undefined}
+          updateEquipment={isCatalogueEditable ? updateEquipment : undefined}
+          removeEquipment={isCatalogueEditable ? removeEquipment : undefined}
           startDate={startDate}
           columnLabels={equipmentColumnLabels}
           groupedColumnLabels={groupedEquipmentColumnLabels}
-          editableValues={equipmentEditable ? ['percentageQuota'] : undefined}
+          editableValues={isCatalogueEditable ? ['percentageQuota'] : undefined}
         />
         <FlexRow
           style={{

--- a/src/equipmentCatalogue/CatalogueEquipmentList.tsx
+++ b/src/equipmentCatalogue/CatalogueEquipmentList.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite'
 import { useMutationData } from '../util/useMutationData'
 import {
   removeEquipmentMutation,
-  updateCatalogueEquipmentDataMutation,
+  refreshEquipmentInCatalogueMutation,
   updateEquipmentCatalogueQuotaMutation,
 } from '../equipment/equipmentQuery'
 import { EquipmentWithQuota } from '../equipment/equipmentUtils'
@@ -54,7 +54,7 @@ const CatalogueEquipmentList: React.FC<PropTypes> = observer(
     let [execUpdateEquipment] = useMutationData(updateEquipmentCatalogueQuotaMutation)
 
     let [execUpdateEquipmentData, { loading: equipmentUpdateLoading }] = useMutationData(
-      updateCatalogueEquipmentDataMutation
+      refreshEquipmentInCatalogueMutation
     )
 
     let updateEquipment = useCallback(

--- a/src/equipmentCatalogue/EquipmentCatalogue.tsx
+++ b/src/equipmentCatalogue/EquipmentCatalogue.tsx
@@ -20,11 +20,18 @@ export type PropTypes = {
   catalogue?: EquipmentCatalogueType
   operatorId: number
   onCatalogueChanged: () => unknown
-  editable: boolean
+  isCatalogueEditable: boolean
 }
 
 const EquipmentCatalogue: React.FC<PropTypes> = observer(
-  ({ editable, procurementUnit, catalogue, startDate, operatorId, onCatalogueChanged }) => {
+  ({
+    isCatalogueEditable,
+    procurementUnit,
+    catalogue,
+    startDate,
+    operatorId,
+    onCatalogueChanged,
+  }) => {
     let { removeAllEquipment, addEquipment, addBatchEquipment } = useEquipmentCrud(
       catalogue,
       onCatalogueChanged
@@ -36,10 +43,10 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
 
     return (
       <EquipmentCatalogueView>
-        {!editable && catalogue && (
+        {!isCatalogueEditable && catalogue && (
           <ValueDisplay item={catalogue} labels={equipmentCatalogueLabels} />
         )}
-        {editable && (
+        {isCatalogueEditable && (
           <EditEquipmentCatalogue
             catalogue={catalogue}
             procurementUnit={procurementUnit}
@@ -55,9 +62,9 @@ const EquipmentCatalogue: React.FC<PropTypes> = observer(
               equipment={equipment}
               startDate={startDate}
               onEquipmentChanged={onCatalogueChanged}
-              equipmentEditable={editable}
+              isCatalogueEditable={isCatalogueEditable}
             />
-            {editable && (
+            {isCatalogueEditable && (
               <AddEquipment
                 operatorId={operatorId}
                 equipment={equipment}

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -11578,7 +11578,7 @@
             "deprecationReason": null
           },
           {
-            "name": "updateEquipmentInCatalogue",
+            "name": "refreshEquipmentInCatalogue",
             "description": null,
             "args": [
               {

--- a/src/inspection/InspectionActions.tsx
+++ b/src/inspection/InspectionActions.tsx
@@ -49,10 +49,11 @@ export type PropTypes = {
   onRefresh: () => unknown
   className?: string
   style?: CSSProperties
+  isEditingAllowed?: boolean
 }
 
 const InspectionActions = observer(
-  ({ inspection, onRefresh, className, style }: PropTypes) => {
+  ({ inspection, onRefresh, className, style, isEditingAllowed = true }: PropTypes) => {
     var [season, setSeason] = useStateValue('globalSeason')
     let hasAdminAccessRights = useHasAdminAccessRights()
     let hasOperatorUserAccessRights = useHasOperatorUserAccessRights(
@@ -187,6 +188,7 @@ const InspectionActions = observer(
             <Button
               buttonStyle={ButtonStyle.NORMAL}
               size={ButtonSize.MEDIUM}
+              disabled={!isEditingAllowed}
               onClick={() => onOpenInspection(inspection)}>
               {inspection.status === InspectionStatus.Draft ? 'Muokkaa' : 'Avaa'}
             </Button>
@@ -205,7 +207,7 @@ const InspectionActions = observer(
                   : ButtonStyle.SECONDARY
               }
               size={ButtonSize.MEDIUM}>
-              Raportit
+              <Text>reports</Text>
             </Button>
           )}
           {canInspectionBeSubmitted && isEditing && (

--- a/src/inspection/InspectionActions.tsx
+++ b/src/inspection/InspectionActions.tsx
@@ -17,11 +17,7 @@ import {
 } from './inspectionQueries'
 import { useStateValue } from '../state/useAppState'
 import { useRouteMatch } from 'react-router-dom'
-import {
-  useHasAccessRights,
-  useHasAdminAccessRights,
-  useHasOperatorUserAccessRights,
-} from '../util/userRoles'
+import { useHasAccessRights, useHasAdminAccessRights } from '../util/userRoles'
 import { text, Text } from '../util/translate'
 import { useShowInfoNotification } from '../util/useShowNotification'
 import { useNavigate } from '../util/urlValue'
@@ -61,9 +57,6 @@ const InspectionActions = observer(
   ({ inspection, onRefresh, className, style, isEditingAllowed = true }: PropTypes) => {
     var [season, setSeason] = useStateValue('globalSeason')
     let hasAdminAccessRights = useHasAdminAccessRights()
-    let hasOperatorUserAccessRights = useHasOperatorUserAccessRights(
-      inspection?.operatorId || undefined
-    )
 
     var { inspectionType } = inspection
     // useRouteMatch returns null if the route does not match
@@ -239,19 +232,16 @@ const InspectionActions = observer(
             </Button>
           )}
 
-          {canUserMakeSanctionable &&
-            canInspectionBeSanctionable &&
-            hasOperatorUserAccessRights &&
-            isEditing && (
-              <Button
-                loading={sanctionableLoading}
-                buttonStyle={ButtonStyle.ACCEPT}
-                size={ButtonSize.MEDIUM}
-                disabled={hasErrors || isDirty}
-                onClick={onMakeInspectionSanctionable}>
-                <Text>inspection_actions_startSanctioning</Text>
-              </Button>
-            )}
+          {canUserMakeSanctionable && canInspectionBeSanctionable && isEditing && (
+            <Button
+              loading={sanctionableLoading}
+              buttonStyle={ButtonStyle.ACCEPT}
+              size={ButtonSize.MEDIUM}
+              disabled={hasErrors || isDirty}
+              onClick={onMakeInspectionSanctionable}>
+              <Text>inspection_actions_startSanctioning</Text>
+            </Button>
+          )}
 
           {[InspectionStatus.Draft, InspectionStatus.InProduction].includes(
             inspection.status

--- a/src/inspection/InspectionActions.tsx
+++ b/src/inspection/InspectionActions.tsx
@@ -61,7 +61,7 @@ const InspectionActions = observer(
     let hasAdminAccessRights = useHasAdminAccessRights()
 
     let canEditInspection = useCanEditInspection({
-      inspection,
+      inspectionType: inspection.inspectionType,
       operatorId: globalOperator.id,
     })
 
@@ -180,14 +180,8 @@ const InspectionActions = observer(
       (inspectionType === InspectionType.Post &&
         inspection.status === InspectionStatus.Sanctionable)
 
-    let allowedRolesToSubmit: UserRole[] = []
-    if (inspection.inspectionType === InspectionType.Pre) {
-      allowedRolesToSubmit = [UserRole.Admin, UserRole.Operator]
-    } else {
-      allowedRolesToSubmit = [UserRole.Admin]
-    }
-    let canUserSubmit = useHasAccessRights({
-      allowedRoles: allowedRolesToSubmit,
+    let canUserSubmit = useCanEditInspection({
+      inspectionType: inspection.inspectionType,
       operatorId: inspection.operatorId,
     })
 

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -16,7 +16,12 @@ import { Text, text } from '../util/translate'
 import { useWatchDirtyForm } from '../util/promptUnsavedChanges'
 import DatePicker from '../common/input/DatePicker'
 import { addDays, max, parseISO } from 'date-fns'
-import { isPostInspection } from './inspectionUtils'
+import {
+  isPostInspection,
+  useCanEditInspection,
+  useCanOpenInspection,
+} from './inspectionUtils'
+import { useStateValue } from '../state/useAppState'
 
 const InspectionConfigView = styled(PageSection)`
   margin: 1rem 0 0;
@@ -35,6 +40,12 @@ export type PropTypes = {
 }
 
 const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection }) => {
+  let [globalOperator] = useStateValue('globalOperator')
+  let canEditInspection = useCanEditInspection({
+    inspection,
+    operatorId: globalOperator.id,
+  })
+
   let initialInspectionInputValues = useMemo(() => {
     let minStartDate = parseISO(inspection.minStartDate)
 
@@ -101,6 +112,7 @@ const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection
           <FlexRow>
             <FormColumn>
               <Input
+                disabled={!canEditInspection}
                 value={pendingInspectionInputValues.name || ''}
                 label={text('inspection_inspectionName')}
                 onChange={(value: string) => {

--- a/src/inspection/InspectionEditor.tsx
+++ b/src/inspection/InspectionEditor.tsx
@@ -42,8 +42,8 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
   ({ refetchData, loading, inspection }) => {
     var isEditable = inspection?.status === InspectionStatus.Draft
 
-    var [season] = useStateValue('globalSeason')
-    var [operator] = useStateValue('globalOperator')
+    var [globalSeason] = useStateValue('globalSeason')
+    var [globalOperator] = useStateValue('globalOperator')
 
     let isUpdating = useRef(false)
     let inspectionType = inspection.inspectionType
@@ -82,16 +82,19 @@ const InspectionEditor: React.FC<InspectionEditorProps> = observer(
     let navigate = useNavigate()
 
     useEffect(() => {
-      if (!inspection || !operatorIsValid(operator) || !seasonIsValid(season)) {
+      if (!inspection || !operatorIsValid(globalOperator) || !seasonIsValid(globalSeason)) {
         return
       }
 
-      if (inspection.operatorId !== operator.operatorId || inspection.seasonId !== season.id) {
+      if (
+        inspection.operatorId !== globalOperator.operatorId ||
+        inspection.seasonId !== globalSeason.id
+      ) {
         navigate.push(
           `/${getInspectionTypeStrings(inspection.inspectionType).path}-inspection/edit`
         )
       }
-    }, [inspection, operator, season, navigate])
+    }, [inspection, globalOperator, globalSeason, navigate])
 
     let hasErrors = inspection?.inspectionErrors?.length !== 0
 

--- a/src/inspection/InspectionItem.tsx
+++ b/src/inspection/InspectionItem.tsx
@@ -106,10 +106,9 @@ const InspectionItem: React.FC<InspectionItemProps> = ({
   showActions = true,
 }) => {
   let [globalOperator] = useStateValue('globalOperator')
-  let canOpenInspection = useCanOpenInspection({
+  let canEditInspection = useCanOpenInspection({
     inspection,
     operatorId: globalOperator.id,
-    isInspectionLoading: false,
   })
 
   let createdBy = getCreatedByUser(inspection)
@@ -129,7 +128,7 @@ const InspectionItem: React.FC<InspectionItemProps> = ({
         <InspectionActionsRow
           inspection={inspection}
           onRefresh={onInspectionUpdated}
-          isEditingAllowed={canOpenInspection}
+          isEditingAllowed={canEditInspection}
         />
       )}
     </InspectionItemView>

--- a/src/inspection/InspectionItem.tsx
+++ b/src/inspection/InspectionItem.tsx
@@ -1,13 +1,14 @@
 import React, { FC } from 'react'
 import styled from 'styled-components/macro'
 import { Inspection, InspectionStatus, User } from '../schema-types'
-import { getCreatedByUser } from './inspectionUtils'
+import { getCreatedByUser, useCanOpenInspection } from './inspectionUtils'
 import ValueDisplay, {
   PropTypes as ValueDisplayPropTypes,
 } from '../common/components/ValueDisplay'
 import InspectionActions from './InspectionActions'
 import { getReadableDate } from '../util/formatDate'
 import { text } from '../util/translate'
+import { useStateValue } from '../state/useAppState'
 
 const InspectionItemView = styled.div<{ status?: InspectionStatus; inEffect?: boolean }>`
   padding: 0.75rem 0.75rem 0;
@@ -78,15 +79,20 @@ const renderValue = (key, val) => {
     case 'inspectionEndDate':
       return getReadableDate(val)
     case 'status':
-      if (val === InspectionStatus.InProduction) {
-        return text('inspection_state_production')
+      if (val === InspectionStatus.Draft) {
+        return text('inspection_state_Draft')
       }
-
+      if (val === InspectionStatus.Sanctionable) {
+        return text('inspection_state_Sanctionable')
+      }
       if (val === InspectionStatus.InReview) {
-        return text('inspection_state_review')
+        return text('inspection_state_Review')
+      }
+      if (val === InspectionStatus.InProduction) {
+        return text('inspection_state_Production')
       }
 
-      return text('inspection_state_draft')
+      return `Inspection status not being supported: ${val}`
     default:
       return val
   }
@@ -99,6 +105,13 @@ const InspectionItem: React.FC<InspectionItemProps> = ({
   onInspectionUpdated = () => {},
   showActions = true,
 }) => {
+  let [globalOperator] = useStateValue('globalOperator')
+  let canOpenInspection = useCanOpenInspection({
+    inspection,
+    operatorId: globalOperator.id,
+    isInspectionLoading: false,
+  })
+
   let createdBy = getCreatedByUser(inspection)
 
   return (
@@ -113,7 +126,11 @@ const InspectionItem: React.FC<InspectionItemProps> = ({
         renderValue={renderValue}
       />
       {showActions && inspection && (
-        <InspectionActionsRow inspection={inspection} onRefresh={onInspectionUpdated} />
+        <InspectionActionsRow
+          inspection={inspection}
+          onRefresh={onInspectionUpdated}
+          isEditingAllowed={canOpenInspection}
+        />
       )}
     </InspectionItemView>
   )

--- a/src/inspection/InspectionItem.tsx
+++ b/src/inspection/InspectionItem.tsx
@@ -107,7 +107,7 @@ const InspectionItem: React.FC<InspectionItemProps> = ({
 }) => {
   let [globalOperator] = useStateValue('globalOperator')
   let canEditInspection = useCanOpenInspection({
-    inspection,
+    inspectionType: inspection.inspectionType,
     operatorId: globalOperator.id,
   })
 

--- a/src/inspection/SelectInspection.tsx
+++ b/src/inspection/SelectInspection.tsx
@@ -7,6 +7,7 @@ import { FlexRow } from '../common/components/common'
 import { useStateValue } from '../state/useAppState'
 import {
   getInspectionTypeStrings,
+  useCanEditInspection,
   useCreateInspection,
   useNavigateToInspection,
 } from './inspectionUtils'
@@ -97,15 +98,9 @@ const SelectInspection: React.FC<PropTypes> = observer(
     var [globalSeason] = useStateValue('globalSeason')
     var [globalOperator] = useStateValue('globalOperator')
 
-    let allowedRoles: UserRole[] = []
-    if (inspectionType === InspectionType.Pre) {
-      allowedRoles = [UserRole.Admin, UserRole.Operator]
-    } else {
-      allowedRoles = [UserRole.Admin]
-    }
-    let canCreateInspection = useHasAccessRights({
-      allowedRoles,
-      operatorId: globalOperator?.id,
+    let canCreateInspection = useCanEditInspection({
+      inspectionType,
+      operatorId: globalOperator.operatorId,
     })
 
     var navigateToInspection = useNavigateToInspection(inspectionType)

--- a/src/inspection/inspectionUtils.ts
+++ b/src/inspection/inspectionUtils.ts
@@ -242,11 +242,11 @@ export function isPostInspection(inspection: unknown): inspection is PostInspect
 export function useCanOpenInspection({
   inspection,
   operatorId,
-  isInspectionLoading,
+  isInspectionLoading = false,
 }: {
   inspection: Inspection
   operatorId: number
-  isInspectionLoading: boolean
+  isInspectionLoading?: boolean
 }): boolean {
   const [user] = useStateValue('user')
 
@@ -264,6 +264,29 @@ export function useCanOpenInspection({
     }
   } else {
     allowedRoles = [UserRole.Admin, UserRole.Hsl, UserRole.Operator]
+  }
+
+  return hasAccessRights({
+    user,
+    allowedRoles,
+    operatorId,
+  })
+}
+
+export function useCanEditInspection({
+  inspection,
+  operatorId,
+}: {
+  inspection: Inspection
+  operatorId: number
+}): boolean {
+  const [user] = useStateValue('user')
+
+  let allowedRoles: UserRole[] = []
+  if (isPreInspection(inspection)) {
+    allowedRoles = [UserRole.Admin, UserRole.Operator]
+  } else {
+    allowedRoles = [UserRole.Admin]
   }
 
   return hasAccessRights({

--- a/src/inspection/inspectionUtils.ts
+++ b/src/inspection/inspectionUtils.ts
@@ -240,30 +240,25 @@ export function isPostInspection(inspection: unknown): inspection is PostInspect
 }
 
 export function useCanOpenInspection({
-  inspection,
+  inspectionType,
+  inspectionStatus,
   operatorId,
-  isInspectionLoading = false,
 }: {
-  inspection: Inspection
+  inspectionType: InspectionType
+  inspectionStatus?: InspectionStatus
   operatorId: number
-  isInspectionLoading?: boolean
 }): boolean {
   const [user] = useStateValue('user')
 
-  // Inspection was not found after loading: user can't open it
-  if (!inspection || (!inspection && !isInspectionLoading)) {
-    return false
-  }
-
-  let allowedRoles: UserRole[] = []
-  if (inspection.status === InspectionStatus.Draft) {
-    if (isPreInspection(inspection)) {
+  let allowedRoles: 'all' | UserRole[] = []
+  if (inspectionStatus === InspectionStatus.Draft) {
+    if (inspectionType === InspectionType.Pre) {
       allowedRoles = [UserRole.Admin, UserRole.Operator]
     } else {
       allowedRoles = [UserRole.Admin]
     }
   } else {
-    allowedRoles = [UserRole.Admin, UserRole.Hsl, UserRole.Operator]
+    allowedRoles = 'all'
   }
 
   return hasAccessRights({
@@ -274,16 +269,17 @@ export function useCanOpenInspection({
 }
 
 export function useCanEditInspection({
-  inspection,
+  inspectionType,
   operatorId,
 }: {
-  inspection: Inspection
-  operatorId: number
+  inspectionType: InspectionType
+  operatorId?: number
 }): boolean {
   const [user] = useStateValue('user')
 
   let allowedRoles: UserRole[] = []
-  if (isPreInspection(inspection)) {
+
+  if (inspectionType === InspectionType.Pre) {
     allowedRoles = [UserRole.Admin, UserRole.Operator]
   } else {
     allowedRoles = [UserRole.Admin]

--- a/src/page/EditContractPage.tsx
+++ b/src/page/EditContractPage.tsx
@@ -5,7 +5,7 @@ import { Redirect, RouteChildrenProps, useHistory, useParams } from 'react-route
 import { useQueryData } from '../util/useQueryData'
 import { contractQuery } from '../contract/contractQueries'
 import ContractEditor from '../contract/ContractEditor'
-import { Contract, UserRole } from '../schema-types'
+import { Contract } from '../schema-types'
 import { useStateValue } from '../state/useAppState'
 import { useHasAccessRights, useHasAdminAccessRights } from '../util/userRoles'
 import { LoadingDisplay } from '../common/components/Loading'
@@ -28,10 +28,12 @@ const EditContractPage: React.FC<PropTypes> = observer(() => {
   let { contractId = '' } = useParams<{ contractId?: string }>()
 
   let [globalOperator] = useStateValue('globalOperator')
+
   let hasAccessRights = useHasAccessRights({
-    allowedRoles: [UserRole.Admin, UserRole.Hsl, UserRole.Operator],
+    allowedRoles: 'all',
     operatorId: globalOperator?.id,
   })
+
   let hasAdminAccessRights = useHasAdminAccessRights()
   let isNew = contractId === 'new'
 

--- a/src/page/EditContractPage.tsx
+++ b/src/page/EditContractPage.tsx
@@ -5,9 +5,9 @@ import { Redirect, RouteChildrenProps, useHistory, useParams } from 'react-route
 import { useQueryData } from '../util/useQueryData'
 import { contractQuery } from '../contract/contractQueries'
 import ContractEditor from '../contract/ContractEditor'
-import { Contract } from '../schema-types'
+import { Contract, UserRole } from '../schema-types'
 import { useStateValue } from '../state/useAppState'
-import { useHasAdminAccessRights, useHasOperatorUserAccessRights } from '../util/userRoles'
+import { useHasAccessRights, useHasAdminAccessRights } from '../util/userRoles'
 import { LoadingDisplay } from '../common/components/Loading'
 import { Page, PageContainer } from '../common/components/common'
 import { useRefetch } from '../util/useRefetch'
@@ -28,7 +28,10 @@ const EditContractPage: React.FC<PropTypes> = observer(() => {
   let { contractId = '' } = useParams<{ contractId?: string }>()
 
   let [globalOperator] = useStateValue('globalOperator')
-  let hasOperatorAccess = useHasOperatorUserAccessRights(globalOperator?.id)
+  let hasAccessRights = useHasAccessRights({
+    allowedRoles: [UserRole.Admin, UserRole.Hsl, UserRole.Operator],
+    operatorId: globalOperator?.id,
+  })
   let hasAdminAccessRights = useHasAdminAccessRights()
   let isNew = contractId === 'new'
 
@@ -49,7 +52,7 @@ const EditContractPage: React.FC<PropTypes> = observer(() => {
     }
   }, [contractId, contract, loading, history])
 
-  if (!hasOperatorAccess) {
+  if (!hasAccessRights) {
     return <Redirect to="/contract" />
   }
 

--- a/src/page/EditInspectionPage.tsx
+++ b/src/page/EditInspectionPage.tsx
@@ -94,13 +94,13 @@ export type PropTypes = {
 const EditInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) => {
   let { inspectionId = '' } = useParams<{ inspectionId?: string }>()
 
-  var [season] = useStateValue('globalSeason')
-  var [operator] = useStateValue('globalOperator')
+  var [globalSeason] = useStateValue('globalSeason')
+  var [globalOperator] = useStateValue('globalOperator')
 
   var showErrorNotification = useShowErrorNotification()
   var navigateToInspection = useNavigateToInspection(inspectionType)
 
-  let { data: inspection, loading: inspectionLoading, refetch } = useInspectionById(
+  let { data: inspection, loading: isInspectionLoading, refetch } = useInspectionById(
     inspectionId
   )
 
@@ -154,7 +154,7 @@ const EditInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) =>
   return (
     <EditInspectionView>
       <InspectionContext.Provider value={inspection || null}>
-        <PageTitle loading={inspectionLoading} onRefresh={refetch}>
+        <PageTitle loading={isInspectionLoading} onRefresh={refetch}>
           <InspectionTypeContainer>
             {inspection?.status !== InspectionStatus.InProduction
               ? typeStrings.prefixLC
@@ -177,18 +177,18 @@ const EditInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) =>
           )}
         </PageTitle>
         <EditInspectionPageContainer>
-          {!operatorIsValid(operator) || !seasonIsValid(season) ? (
+          {!operatorIsValid(globalOperator) || !seasonIsValid(globalSeason) ? (
             <MessageContainer style={{ margin: '1rem' }}>
               <MessageView>
                 <Text>inspectionPage_selectOperatorAndSeason</Text>
               </MessageView>
             </MessageContainer>
-          ) : !inspection && !inspectionLoading ? (
+          ) : !inspection && !isInspectionLoading ? (
             <MessageContainer style={{ margin: '1rem' }}>
               <MessageView>
                 <Text
                   keyValueMap={{
-                    inspection: typeStrings.prefixLC,
+                    inspection: typeStrings.prefix,
                   }}>
                   inspectionPage_inspectionNotFound
                 </Text>
@@ -211,7 +211,7 @@ const EditInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) =>
                         name="create"
                         path="/"
                         label={text('inspectionPage_inspectionInformation')}
-                        loading={inspectionLoading}
+                        loading={isInspectionLoading}
                         refetchData={refetch}
                         inspection={inspection}
                       />

--- a/src/page/EditInspectionPage.tsx
+++ b/src/page/EditInspectionPage.tsx
@@ -185,7 +185,14 @@ const EditInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) =>
             </MessageContainer>
           ) : !inspection && !inspectionLoading ? (
             <MessageContainer style={{ margin: '1rem' }}>
-              <MessageView>Haettu {typeStrings.prefixLC}tarkastus ei löytynyt.</MessageView>
+              <MessageView>
+                <Text
+                  keyValueMap={{
+                    inspection: typeStrings.prefixLC,
+                  }}>
+                  inspectionPage_inspectionNotFound
+                </Text>
+              </MessageView>
               <Button onClick={() => navigateToInspection()}>
                 <Text>back</Text>
               </Button>

--- a/src/page/InspectionsPage.tsx
+++ b/src/page/InspectionsPage.tsx
@@ -8,11 +8,11 @@ import { MessageContainer, MessageView } from '../common/components/Messages'
 import { getInspectionTypeStrings, useFetchInspections } from '../inspection/inspectionUtils'
 import { PageTitle } from '../common/components/PageTitle'
 import { operatorIsValid } from '../common/input/SelectOperator'
-import { InspectionType } from '../schema-types'
+import { InspectionType, UserRole } from '../schema-types'
 import { RouteChildrenProps } from 'react-router-dom'
 import { useNavigate } from '../util/urlValue'
 import { useStateValue } from '../state/useAppState'
-import { useHasAdminAccessRights, useHasOperatorUserAccessRights } from '../util/userRoles'
+import { useHasAccessRights } from '../util/userRoles'
 
 type PropTypes = {
   children?: React.ReactNode
@@ -23,10 +23,17 @@ const InspectionsPage: React.FC<PropTypes> = observer(({ inspectionType }) => {
   let [{ operator, inspections }, loading, refetch] = useFetchInspections(inspectionType)
 
   var [globalOperator] = useStateValue('globalOperator')
-  let hasOperatorAccessRights = useHasOperatorUserAccessRights(globalOperator?.id)
-  const hasAdminAccessRights = useHasAdminAccessRights()
-  let canCreateInspection =
-    inspectionType === InspectionType.Pre ? hasOperatorAccessRights : hasAdminAccessRights
+
+  let allowedRoles: UserRole[] = []
+  if (inspectionType === InspectionType.Pre) {
+    allowedRoles = [UserRole.Admin, UserRole.Operator]
+  } else {
+    allowedRoles = [UserRole.Admin]
+  }
+  let canCreateInspection = useHasAccessRights({
+    allowedRoles,
+    operatorId: globalOperator?.id,
+  })
 
   let typeStrings = getInspectionTypeStrings(inspectionType)
   let navigate = useNavigate()

--- a/src/page/InspectionsPage.tsx
+++ b/src/page/InspectionsPage.tsx
@@ -11,6 +11,8 @@ import { operatorIsValid } from '../common/input/SelectOperator'
 import { InspectionType } from '../schema-types'
 import { RouteChildrenProps } from 'react-router-dom'
 import { useNavigate } from '../util/urlValue'
+import { useStateValue } from '../state/useAppState'
+import { useHasAdminAccessRights, useHasOperatorUserAccessRights } from '../util/userRoles'
 
 type PropTypes = {
   children?: React.ReactNode
@@ -19,6 +21,12 @@ type PropTypes = {
 
 const InspectionsPage: React.FC<PropTypes> = observer(({ inspectionType }) => {
   let [{ operator, inspections }, loading, refetch] = useFetchInspections(inspectionType)
+
+  var [globalOperator] = useStateValue('globalOperator')
+  let hasOperatorAccessRights = useHasOperatorUserAccessRights(globalOperator?.id)
+  const hasAdminAccessRights = useHasAdminAccessRights()
+  let canCreateInspection =
+    inspectionType === InspectionType.Pre ? hasOperatorAccessRights : hasAdminAccessRights
 
   let typeStrings = getInspectionTypeStrings(inspectionType)
   let navigate = useNavigate()
@@ -29,10 +37,12 @@ const InspectionsPage: React.FC<PropTypes> = observer(({ inspectionType }) => {
         loading={loading}
         onRefresh={refetch}
         headerButtons={
-          <Button onClick={() => navigate.push(`${typeStrings.path}-inspection/edit`)}>
-            <Plus fill="white" width="1rem" height="1rem" />{' '}
-            <span>Uusi {typeStrings.prefix}tarkastus</span>
-          </Button>
+          canCreateInspection ? (
+            <Button onClick={() => navigate.push(`${typeStrings.path}-inspection/edit`)}>
+              <Plus fill="white" width="1rem" height="1rem" />{' '}
+              <span>Uusi {typeStrings.prefix}tarkastus</span>
+            </Button>
+          ) : undefined
         }>
         {typeStrings.prefix}tarkastukset
       </PageTitle>

--- a/src/page/InspectionsPage.tsx
+++ b/src/page/InspectionsPage.tsx
@@ -5,14 +5,17 @@ import InspectionsList from '../inspection/InspectionsList'
 import { Plus } from '../common/icon/Plus'
 import { Button } from '../common/components/buttons/Button'
 import { MessageContainer, MessageView } from '../common/components/Messages'
-import { getInspectionTypeStrings, useFetchInspections } from '../inspection/inspectionUtils'
+import {
+  getInspectionTypeStrings,
+  useCanEditInspection,
+  useFetchInspections,
+} from '../inspection/inspectionUtils'
 import { PageTitle } from '../common/components/PageTitle'
 import { operatorIsValid } from '../common/input/SelectOperator'
-import { InspectionType, UserRole } from '../schema-types'
+import { InspectionType } from '../schema-types'
 import { RouteChildrenProps } from 'react-router-dom'
 import { useNavigate } from '../util/urlValue'
 import { useStateValue } from '../state/useAppState'
-import { useHasAccessRights } from '../util/userRoles'
 
 type PropTypes = {
   children?: React.ReactNode
@@ -24,14 +27,8 @@ const InspectionsPage: React.FC<PropTypes> = observer(({ inspectionType }) => {
 
   var [globalOperator] = useStateValue('globalOperator')
 
-  let allowedRoles: UserRole[] = []
-  if (inspectionType === InspectionType.Pre) {
-    allowedRoles = [UserRole.Admin, UserRole.Operator]
-  } else {
-    allowedRoles = [UserRole.Admin]
-  }
-  let canCreateInspection = useHasAccessRights({
-    allowedRoles,
+  let canCreateInspection = useCanEditInspection({
+    inspectionType,
     operatorId: globalOperator?.id,
   })
 

--- a/src/page/ProcurementUnitsPage.tsx
+++ b/src/page/ProcurementUnitsPage.tsx
@@ -37,6 +37,7 @@ const ProcurementUnitsPage: React.FC<PropTypes> = observer(() => {
             startDate={globalSeason?.startDate || ''}
             endDate={globalSeason?.endDate || ''}
             contractSelectionDate={getDateObject(globalSeason.startDate)}
+            isOnlyActiveCatalogueVisible={false}
           />
         )}
       </PageContainer>

--- a/src/page/SelectInspectionPage.tsx
+++ b/src/page/SelectInspectionPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Page, PageContainer } from '../common/components/common'
 import { observer } from 'mobx-react-lite'
+import { Text } from '../util/translate'
 import { useStateValue } from '../state/useAppState'
 import { Inspection, InspectionType } from '../schema-types'
 import SelectInspection from '../inspection/SelectInspection'
@@ -38,7 +39,9 @@ const SelectInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) 
   return (
     <Page>
       <PageTitle loading={loading} onRefresh={refetch}>
-        Luo {typeStrings.prefixLC}tarkastus
+        <Text keyValueMap={{ prefix: typeStrings.prefixLC }}>
+          inspectionPage_createNewInspection
+        </Text>
       </PageTitle>
       <PageContainer>
         <SelectInspection

--- a/src/page/SelectInspectionPage.tsx
+++ b/src/page/SelectInspectionPage.tsx
@@ -38,7 +38,7 @@ const SelectInspectionPage: React.FC<PropTypes> = observer(({ inspectionType }) 
   return (
     <Page>
       <PageTitle loading={loading} onRefresh={refetch}>
-        Valitse {typeStrings.prefixLC}tarkastus muokattavaksi
+        Luo {typeStrings.prefixLC}tarkastus
       </PageTitle>
       <PageContainer>
         <SelectInspection

--- a/src/postInspection/SanctionsContainer.tsx
+++ b/src/postInspection/SanctionsContainer.tsx
@@ -24,6 +24,7 @@ import { DEBUG, DEFAULT_DECIMALS } from '../constants'
 import { round } from '../util/round'
 import { ValueOf } from '../type/common'
 import { useNavigate } from '../util/urlValue'
+import { useHasAdminAccessRights } from '../util/userRoles'
 
 const PostInspectionSanctionsView = styled.div`
   min-height: 100%;
@@ -157,6 +158,8 @@ const SanctionsContainer = observer(({ inspection }: PropTypes) => {
   let tableState = useTableState()
   let { filters = [], sort = [] } = tableState
   let [pendingValues, setPendingValues] = useState<EditValue<Sanction>[]>([])
+
+  let canAbandonSanctions = useHasAdminAccessRights()
 
   let { data: sanctionsData, loading, refetch } = useQueryData<SanctionsResponse>(
     sanctionsQuery,
@@ -351,13 +354,15 @@ const SanctionsContainer = observer(({ inspection }: PropTypes) => {
   return (
     <PostInspectionSanctionsView>
       <FunctionsRow>
-        <Button
-          loading={abandonSanctionsLoading}
-          buttonStyle={ButtonStyle.SECONDARY_REMOVE}
-          size={ButtonSize.SMALL}
-          onClick={onAbandonSanctions}>
-          <Text>inspection_actions_abandonSanctions</Text>
-        </Button>
+        {canAbandonSanctions && (
+          <Button
+            loading={abandonSanctionsLoading}
+            buttonStyle={ButtonStyle.SECONDARY_REMOVE}
+            size={ButtonSize.SMALL}
+            onClick={onAbandonSanctions}>
+            <Text>inspection_actions_abandonSanctions</Text>
+          </Button>
+        )}
         {DEBUG && (
           <Button
             loading={devLoadingSanctions}

--- a/src/preInspection/PreInspectionEditor.tsx
+++ b/src/preInspection/PreInspectionEditor.tsx
@@ -58,6 +58,7 @@ const PreInspectionEditor: React.FC<PreInspectionProps> = observer(
             startDate={inspection.inspectionStartDate}
             endDate={inspection.inspectionEndDate}
             contractSelectionDate={getDateObject(inspection.startDate || '')}
+            isOnlyActiveCatalogueVisible={true}
           />
         )}
         {DEBUG && (

--- a/src/procurementUnit/ProcurementUnitItem.tsx
+++ b/src/procurementUnit/ProcurementUnitItem.tsx
@@ -38,6 +38,7 @@ export type PropTypes = {
   className?: string
   validationErrors: ValidationErrorData[]
   contractSelectionDate: Date
+  isOnlyActiveCatalogueVisible: boolean
 }
 
 const operatingAreaNameLocalizationObj = {
@@ -58,6 +59,7 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
     className,
     validationErrors = [],
     contractSelectionDate,
+    isOnlyActiveCatalogueVisible,
   }) => {
     const { currentContracts = [], routes = [] } = procurementUnit || {}
 
@@ -177,6 +179,7 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
                 isCatalogueEditable={isCatalogueEditable}
                 catalogueInvalid={catalogueInvalid}
                 requirementsInvalid={requirementsInvalid}
+                isOnlyActiveCatalogueVisible={isOnlyActiveCatalogueVisible}
               />
             )}
           </ExpandableSection>

--- a/src/procurementUnit/ProcurementUnitItem.tsx
+++ b/src/procurementUnit/ProcurementUnitItem.tsx
@@ -32,7 +32,7 @@ export type PropTypes = {
   expanded?: boolean
   startDate: string
   endDate: string
-  catalogueEditable: boolean
+  isCatalogueEditable: boolean
   requirementsEditable: boolean
   showExecutionRequirements: boolean
   className?: string
@@ -48,7 +48,7 @@ const operatingAreaNameLocalizationObj = {
 
 const ProcurementUnitItem: React.FC<PropTypes> = observer(
   ({
-    catalogueEditable,
+    isCatalogueEditable,
     requirementsEditable,
     showExecutionRequirements,
     startDate,
@@ -174,7 +174,7 @@ const ProcurementUnitItem: React.FC<PropTypes> = observer(
                   displayedContractUnit ? displayedContractUnit.id : undefined
                 }
                 requirementsEditable={requirementsEditable}
-                catalogueEditable={catalogueEditable}
+                isCatalogueEditable={isCatalogueEditable}
                 catalogueInvalid={catalogueInvalid}
                 requirementsInvalid={requirementsInvalid}
               />

--- a/src/procurementUnit/ProcurementUnitItemContent.tsx
+++ b/src/procurementUnit/ProcurementUnitItemContent.tsx
@@ -59,7 +59,7 @@ type ContentPropTypes = {
   startDate: string
   endDate: string
   procurementUnitId: string
-  catalogueEditable: boolean
+  isCatalogueEditable: boolean
   displayedContractUnitId?: string
   requirementsEditable: boolean
   isVisible: boolean
@@ -73,7 +73,7 @@ const ProcurementUnitItemContent = observer(
     startDate,
     endDate,
     procurementUnitId,
-    catalogueEditable,
+    isCatalogueEditable,
     displayedContractUnitId,
     requirementsEditable,
     isVisible,
@@ -117,10 +117,10 @@ const ProcurementUnitItemContent = observer(
     const catalogues: EquipmentCatalogueType[] = useMemo(() => {
       let unitCatalogues = procurementUnit?.equipmentCatalogues || []
 
-      return catalogueEditable
+      return isCatalogueEditable
         ? unitCatalogues
         : unitCatalogues.filter((cat) => isBetween(startDate, cat.startDate, cat.endDate))
-    }, [procurementUnit, catalogueEditable, startDate])
+    }, [procurementUnit, isCatalogueEditable, startDate])
 
     let hasEquipment = catalogues
       .filter((cat) => isBetween(startDate, cat.startDate, cat.endDate))
@@ -162,7 +162,7 @@ const ProcurementUnitItemContent = observer(
       })
 
       setUnitEditable(false)
-    }, [medianAgeValue, catalogueEditable])
+    }, [medianAgeValue, isCatalogueEditable])
 
     const inspectionStartDate = useMemo(() => parseISO(startDate), [startDate])
 
@@ -278,7 +278,7 @@ const ProcurementUnitItemContent = observer(
                       catalogue={catalogue}
                       operatorId={procurementUnit.operatorId}
                       onCatalogueChanged={updateViewData}
-                      editable={catalogueEditable}
+                      isCatalogueEditable={isCatalogueEditable}
                     />
                   </ExpandableSection>
                 )
@@ -288,7 +288,7 @@ const ProcurementUnitItemContent = observer(
                   <Text>procurementUnit_noCatalogueForUnit</Text>
                 </MessageView>
               )}
-              {catalogueEditable && (
+              {isCatalogueEditable && (
                 <EditEquipmentCatalogue
                   onChange={updateViewData}
                   procurementUnit={procurementUnit}

--- a/src/procurementUnit/ProcurementUnitItemContent.tsx
+++ b/src/procurementUnit/ProcurementUnitItemContent.tsx
@@ -29,6 +29,7 @@ import ValueDisplay from '../common/components/ValueDisplay'
 import { Button } from '../common/components/buttons/Button'
 import { LinkButton } from '../common/components/buttons/LinkButton'
 import { useNavigate } from '../util/urlValue'
+import { useHasAdminAccessRights } from '../util/userRoles'
 
 const procurementUnitLabels = {
   medianAgeRequirement: text('procurementUnit_ageRequirement'),
@@ -88,6 +89,8 @@ const ProcurementUnitItemContent = observer(
       endDate,
     }
 
+    let hasAdminAccessRights = useHasAdminAccessRights()
+
     // Get the operating units for the selected operator.
     const { data: procurementUnit, loading, refetch } =
       useQueryData<ProcurementUnitType>(procurementUnitQuery, {
@@ -129,18 +132,18 @@ const ProcurementUnitItemContent = observer(
       .some((cat) => cat.equipmentQuotas?.length !== 0)
 
     let [medianAgeValue, setMedianAgeValue] = useState('')
-    let [unitEditable, setUnitEditable] = useState(false)
+    let [isUnitEditable, setIsUnitEditable] = useState(false)
 
     let onEditProcurementUnit = useCallback(() => {
-      if (!unitEditable) {
+      if (!isUnitEditable) {
         setMedianAgeValue((procurementUnit?.medianAgeRequirement || 0) + '')
       }
 
-      setUnitEditable((cur) => !cur)
-    }, [unitEditable, procurementUnit])
+      setIsUnitEditable((cur) => !cur)
+    }, [isUnitEditable, procurementUnit])
 
     let onCancelEdit = useCallback(() => {
-      setUnitEditable(false)
+      setIsUnitEditable(false)
     }, [])
 
     let onChangeProcurementUnit = useCallback(
@@ -163,7 +166,7 @@ const ProcurementUnitItemContent = observer(
         },
       })
 
-      setUnitEditable(false)
+      setIsUnitEditable(false)
     }, [medianAgeValue, isCatalogueEditable])
 
     const inspectionStartDate = useMemo(() => parseISO(startDate), [startDate])
@@ -221,7 +224,7 @@ const ProcurementUnitItemContent = observer(
               })}
             </>
           )}
-          {!unitEditable ? (
+          {!isUnitEditable ? (
             <ValueDisplay
               renderValue={(key, val) => `${val} vuotta`}
               item={{
@@ -229,11 +232,13 @@ const ProcurementUnitItemContent = observer(
                 calculatedMedianAgeRequirement: calcMedianAgeRequirement,
               }}
               labels={procurementUnitLabels}>
-              <Button
-                style={{ marginLeft: 'auto', marginTop: 'auto' }}
-                onClick={onEditProcurementUnit}>
-                <Text>edit</Text>
-              </Button>
+              {hasAdminAccessRights && (
+                <Button
+                  style={{ marginLeft: 'auto', marginTop: 'auto' }}
+                  onClick={onEditProcurementUnit}>
+                  <Text>edit</Text>
+                </Button>
+              )}
             </ValueDisplay>
           ) : (
             <ItemForm

--- a/src/procurementUnit/ProcurementUnitItemContent.tsx
+++ b/src/procurementUnit/ProcurementUnitItemContent.tsx
@@ -65,6 +65,7 @@ type ContentPropTypes = {
   isVisible: boolean
   catalogueInvalid: boolean
   requirementsInvalid: boolean
+  isOnlyActiveCatalogueVisible: boolean
 }
 
 const ProcurementUnitItemContent = observer(
@@ -79,6 +80,7 @@ const ProcurementUnitItemContent = observer(
     isVisible,
     catalogueInvalid,
     requirementsInvalid,
+    isOnlyActiveCatalogueVisible,
   }: ContentPropTypes) => {
     let unitQueryVariables = {
       procurementUnitId,
@@ -117,10 +119,10 @@ const ProcurementUnitItemContent = observer(
     const catalogues: EquipmentCatalogueType[] = useMemo(() => {
       let unitCatalogues = procurementUnit?.equipmentCatalogues || []
 
-      return isCatalogueEditable
-        ? unitCatalogues
-        : unitCatalogues.filter((cat) => isBetween(startDate, cat.startDate, cat.endDate))
-    }, [procurementUnit, isCatalogueEditable, startDate])
+      return isOnlyActiveCatalogueVisible
+        ? unitCatalogues.filter((cat) => isBetween(startDate, cat.startDate, cat.endDate))
+        : unitCatalogues
+    }, [procurementUnit, isOnlyActiveCatalogueVisible, startDate])
 
     let hasEquipment = catalogues
       .filter((cat) => isBetween(startDate, cat.startDate, cat.endDate))

--- a/src/procurementUnit/ProcurementUnits.tsx
+++ b/src/procurementUnit/ProcurementUnits.tsx
@@ -14,8 +14,13 @@ import { procurementUnitsQuery } from './procurementUnitsQuery'
 import { LoadingDisplay } from '../common/components/Loading'
 import { InspectionContext } from '../inspection/InspectionContext'
 import { MessageView } from '../common/components/Messages'
-import { ProcurementUnit as ProcurementUnitType, ValidationErrorData } from '../schema-types'
+import {
+  ProcurementUnit as ProcurementUnitType,
+  UserRole,
+  ValidationErrorData,
+} from '../schema-types'
 import { text, Text } from '../util/translate'
+import { useHasAccessRights } from '../util/userRoles'
 
 const ProcurementUnitsView = styled(TransparentPageSection)``
 
@@ -39,7 +44,13 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
   }) => {
     const inspection = useContext(InspectionContext)
 
-    let catalogueEditable = !inspection
+    let isCatalogueEditable =
+      !inspection &&
+      useHasAccessRights({
+        operatorId,
+        allowedRoles: [UserRole.Admin, UserRole.Operator],
+      })
+
     let showExecutionRequirements = !!inspection
 
     const [procurementUnitsExpanded, setProcurementUnitsExpanded] = useState(false)
@@ -98,7 +109,7 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
                 <ProcurementUnitItem
                   validationErrors={unitErrors}
                   requirementsEditable={requirementsEditable}
-                  catalogueEditable={catalogueEditable}
+                  isCatalogueEditable={isCatalogueEditable}
                   showExecutionRequirements={showExecutionRequirements}
                   key={procurementUnit.id}
                   startDate={startDate}

--- a/src/procurementUnit/ProcurementUnits.tsx
+++ b/src/procurementUnit/ProcurementUnits.tsx
@@ -31,6 +31,7 @@ export type PropTypes = {
   requirementsEditable: boolean
   getErrorsById?: (objectId: string) => ValidationErrorData[]
   contractSelectionDate: Date
+  isOnlyActiveCatalogueVisible: boolean
 }
 
 const ProcurementUnits: React.FC<PropTypes> = observer(
@@ -41,6 +42,7 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
     startDate,
     endDate,
     contractSelectionDate,
+    isOnlyActiveCatalogueVisible,
   }) => {
     const inspection = useContext(InspectionContext)
 
@@ -50,7 +52,6 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
         operatorId,
         allowedRoles: [UserRole.Admin, UserRole.Operator],
       })
-
     let showExecutionRequirements = !!inspection
 
     const [procurementUnitsExpanded, setProcurementUnitsExpanded] = useState(false)
@@ -117,6 +118,7 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
                   procurementUnit={procurementUnit}
                   expanded={procurementUnitsExpanded}
                   contractSelectionDate={contractSelectionDate}
+                  isOnlyActiveCatalogueVisible={isOnlyActiveCatalogueVisible}
                 />
               )
             })}

--- a/src/procurementUnit/ProcurementUnits.tsx
+++ b/src/procurementUnit/ProcurementUnits.tsx
@@ -52,6 +52,7 @@ const ProcurementUnits: React.FC<PropTypes> = observer(
         operatorId,
         allowedRoles: [UserRole.Admin, UserRole.Operator],
       })
+
     let showExecutionRequirements = !!inspection
 
     const [procurementUnitsExpanded, setProcurementUnitsExpanded] = useState(false)

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -954,7 +954,7 @@ export type Mutation = {
   updateEquipmentCatalogue: EquipmentCatalogue
   addEquipmentToCatalogue?: Maybe<EquipmentCatalogue>
   batchAddToEquipmentCatalogue?: Maybe<EquipmentCatalogue>
-  updateEquipmentInCatalogue: EquipmentCatalogue
+  refreshEquipmentInCatalogue: EquipmentCatalogue
   removeEquipmentFromCatalogue?: Maybe<EquipmentCatalogue>
   removeAllEquipmentFromCatalogue: EquipmentCatalogue
   removeEquipmentCatalogue: Scalars['Boolean']
@@ -1057,7 +1057,7 @@ export type MutationBatchAddToEquipmentCatalogueArgs = {
   catalogueId: Scalars['String']
 }
 
-export type MutationUpdateEquipmentInCatalogueArgs = {
+export type MutationRefreshEquipmentInCatalogueArgs = {
   catalogueId: Scalars['String']
 }
 

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -171,7 +171,7 @@
 
   "inspectionPage_selectOperatorAndSeason": "Valitse liikennöitsijä ja kausi.",
   "inspectionPage_createNewInspection": "Luo uusi ${prefix}tarkastus",
-  "inspectionPage_inspectionNotFound": "Tarkastusta ${inspection}ei löytynyt.",
+  "inspectionPage_inspectionNotFound": "${inspection}tarkastusta ei löytynyt tai sinulla ei ole oikeuksia nähdä sitä.",
   "inspectionPage_inspectionInformation": "Tarkastuksen tiedot",
   "inspectionPage_results": "Tulokset",
   "inspectionPage_sanctions": "Sanktiointi",
@@ -205,9 +205,9 @@
 
   "inspection_state_Draft": "Muokattavissa",
   "inspection_state_Processing": "Käsittelee tietoja",
+  "inspection_state_Sanctionable": "Sanktioitavana",
   "inspection_state_InReview": "Hyväksyttävänä",
   "inspection_state_InProduction": "Tuotannossa",
-  "inspection_state_Sanctionable": "Sanktiointi",
 
   "inspectionList_noInspectionInProduction": "Tällä kaudella ei ole tuotannossa-olevaa ${inspection}tarkastusta.",
   "inspectionList_youAreHere": "Olet tässä",

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -121,7 +121,7 @@
   "executionRequirement_equipmentList": "Suoritevaatimuksen ajoneuvot",
   "executionRequirement_remove": "Poista suoritevaatimus",
   "executionRequirement_unitValues": "Kilpailukohteen suoritearvot",
-  "executionRequirement_missing": "Suoritevaatimukset ei laskettu.",
+  "executionRequirement_missing": "Kohteen suoritevaatimuksia ei ole laskettu.",
   "executionRequirement_create": "Laske kohteen suoritevaatimukset",
   "executionRequirement_removeWarning": "Olet poistamassa tämän kilpailukohteen suoritevaatimukset. Oletko varma?",
   "executionRequirement_refreshWarning": "Kalustoluettelosta löytyvät mutta ei suoritevaatimuksessa olevat ajoneuvot lisätään suoritevaatimukseen. Ok?",

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -171,7 +171,7 @@
 
   "inspectionPage_selectOperatorAndSeason": "Valitse liikennöitsijä ja kausi.",
   "inspectionPage_createNewInspection": "Luo uusi ${prefix}tarkastus",
-  "inspectionPage_inspectionNotFound": "Tarkastusta ei löytynyt.",
+  "inspectionPage_inspectionNotFound": "Tarkastusta ${inspection}ei löytynyt.",
   "inspectionPage_inspectionInformation": "Tarkastuksen tiedot",
   "inspectionPage_results": "Tulokset",
   "inspectionPage_sanctions": "Sanktiointi",

--- a/src/util/userRoles.ts
+++ b/src/util/userRoles.ts
@@ -3,7 +3,7 @@ import { useStateValue } from '../state/useAppState'
 
 export function useHasAdminAccessRights(): boolean {
   const [user] = useStateValue('user')
-  return hasAdminAccessRights()
+  return hasAdminAccessRights(user)
 }
 
 export function useHasHSLUserAccessRights(): boolean {

--- a/src/util/userRoles.ts
+++ b/src/util/userRoles.ts
@@ -13,7 +13,7 @@ export function useHasHSLUserAccessRights(): boolean {
 
 export function useHasOperatorUserAccessRights(operatorId?: number): boolean {
   const [user] = useStateValue('user')
-  return hasOperatorUserAccessRights(user)
+  return hasOperatorUserAccessRights(user, operatorId)
 }
 
 export function useHasAccessRights({
@@ -24,7 +24,18 @@ export function useHasAccessRights({
   operatorId?: number
 }): boolean {
   const [user] = useStateValue('user')
+  return hasAccessRights({ user, allowedRoles, operatorId })
+}
 
+export function hasAccessRights({
+  user,
+  allowedRoles,
+  operatorId,
+}: {
+  user?: User
+  allowedRoles: UserRole[]
+  operatorId?: number
+}): boolean {
   if (!user) {
     throw new Error('Current user not found.')
   }
@@ -43,15 +54,15 @@ export function useHasAccessRights({
   return false
 }
 
-function hasAdminAccessRights(user?: User): boolean {
+export function hasAdminAccessRights(user?: User): boolean {
   return !!user && user.role === UserRole.Admin
 }
 
-function hasHSLUserAccessRights(user?: User): boolean {
+export function hasHSLUserAccessRights(user?: User): boolean {
   return !!user && user.role === UserRole.Hsl
 }
 
-function hasOperatorUserAccessRights(user?: User, operatorId?: number): boolean {
+export function hasOperatorUserAccessRights(user?: User, operatorId?: number): boolean {
   if (!operatorId) {
     return false
   }

--- a/src/util/userRoles.ts
+++ b/src/util/userRoles.ts
@@ -1,32 +1,60 @@
-import { UserRole } from '../schema-types'
+import { User, UserRole } from '../schema-types'
 import { useStateValue } from '../state/useAppState'
 
 export function useHasAdminAccessRights(): boolean {
   const [user] = useStateValue('user')
-  return !!user && user.role === UserRole.Admin
+  return hasAdminAccessRights()
 }
 
 export function useHasHSLUserAccessRights(): boolean {
   const [user] = useStateValue('user')
-
-  if (useHasAdminAccessRights()) {
-    return true
-  }
-
-  return !!user && user.role === UserRole.Hsl
+  return hasHSLUserAccessRights(user)
 }
 
 export function useHasOperatorUserAccessRights(operatorId?: number): boolean {
   const [user] = useStateValue('user')
+  return hasOperatorUserAccessRights(user)
+}
 
-  if (useHasHSLUserAccessRights()) {
+export function useHasAccessRights({
+  allowedRoles,
+  operatorId,
+}: {
+  allowedRoles: UserRole[]
+  operatorId?: number
+}): boolean {
+  const [user] = useStateValue('user')
+
+  if (!user) {
+    throw new Error('Current user not found.')
+  }
+  if (allowedRoles.length === 0) {
+    throw new Error('Guard roles not working, given allowedRoles list is empty.')
+  }
+  if (allowedRoles.includes(UserRole.Admin) && hasAdminAccessRights(user)) {
     return true
   }
+  if (allowedRoles.includes(UserRole.Hsl) && hasHSLUserAccessRights(user)) {
+    return true
+  }
+  if (allowedRoles.includes(UserRole.Operator)) {
+    return hasOperatorUserAccessRights(user, operatorId)
+  }
+  return false
+}
 
+function hasAdminAccessRights(user?: User): boolean {
+  return !!user && user.role === UserRole.Admin
+}
+
+function hasHSLUserAccessRights(user?: User): boolean {
+  return !!user && user.role === UserRole.Hsl
+}
+
+function hasOperatorUserAccessRights(user?: User, operatorId?: number): boolean {
   if (!operatorId) {
     return false
   }
-
   return (
     !!user && user.role === UserRole.Operator && (user.operatorIds || []).includes(operatorId)
   )

--- a/src/util/userRoles.ts
+++ b/src/util/userRoles.ts
@@ -11,7 +11,7 @@ export function useHasHSLUserAccessRights(): boolean {
   return hasHSLUserAccessRights(user)
 }
 
-export function useHasOperatorUserAccessRights(operatorId?: number): boolean {
+export function useHasOperatorUserAccessRights(operatorId: number): boolean {
   const [user] = useStateValue('user')
   return hasOperatorUserAccessRights(user, operatorId)
 }
@@ -20,7 +20,7 @@ export function useHasAccessRights({
   allowedRoles,
   operatorId,
 }: {
-  allowedRoles: UserRole[]
+  allowedRoles: 'all' | UserRole[]
   operatorId?: number
 }): boolean {
   const [user] = useStateValue('user')
@@ -33,24 +33,42 @@ export function hasAccessRights({
   operatorId,
 }: {
   user?: User
-  allowedRoles: UserRole[]
+  allowedRoles: 'all' | UserRole[]
   operatorId?: number
 }): boolean {
   if (!user) {
-    throw new Error('Current user not found.')
+    return false
   }
+
+  if (
+    // If all roles are allowed, check that the user is not blocked. If the user is an operator user,
+    // ensure that it has access to the operatorId.
+    allowedRoles === 'all' &&
+    user.role !== UserRole.Blocked &&
+    // Either the user is not an operator user...
+    (user.role !== UserRole.Operator ||
+      // Or there is an operator ID provided AND the user belongs to the operator ID.
+      (operatorId && (user.operatorIds || []).includes(operatorId)))
+  ) {
+    return true
+  }
+
   if (allowedRoles.length === 0) {
     throw new Error('Guard roles not working, given allowedRoles list is empty.')
   }
+
   if (allowedRoles.includes(UserRole.Admin) && hasAdminAccessRights(user)) {
     return true
   }
+
   if (allowedRoles.includes(UserRole.Hsl) && hasHSLUserAccessRights(user)) {
     return true
   }
-  if (allowedRoles.includes(UserRole.Operator)) {
+
+  if (allowedRoles.includes(UserRole.Operator) && operatorId) {
     return hasOperatorUserAccessRights(user, operatorId)
   }
+
   return false
 }
 
@@ -62,10 +80,14 @@ export function hasHSLUserAccessRights(user?: User): boolean {
   return !!user && user.role === UserRole.Hsl
 }
 
-export function hasOperatorUserAccessRights(user?: User, operatorId?: number): boolean {
+export function hasOperatorUserAccessRights(
+  user: User | undefined,
+  operatorId: number
+): boolean {
   if (!operatorId) {
     return false
   }
+
   return (
     !!user && user.role === UserRole.Operator && (user.operatorIds || []).includes(operatorId)
   )


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/333

Note: currently only admins can accept pre and post inspections. We'll implement double accept later where also operator can accept their owns inspections

Questions:
* Should I remove those methdos marked with TODO: remove? Note: I don't want this PR to be merged with any new TODO's so something needs to be done with them (I found like 5-8 unused resolvers)
* Is guardPlannedUnitExecutionRequirementResolvers OK that it has allowedRoles: [UserRole.HSL]?
* refreshEquipmentInCatalogueMutation: this was OK to be available for all roles
* Shouldn't we remove DEV Load sanctions button from post inspection's page? We have devResolver for that, if ever want to test running some functions in backend.
* "Sopimuksessa mukana toggle" - is the endpoint of this now correctly restricted by role checks? I guess admins and operators can do it or am I right? Can't easilly find which resolver this checkbox calls....

How to test this PR:

* Test every action/resolver with every role (admin, hsl user, operator). Ensure that each action has access rights according to our access right table: https://gitlab.hsl.fi/bultti/bultti-testaus/bultti/-/wikis/Ka%CC%88ytto%CC%88oikeudet
* You should also test opening post inspections that are in DRAFT with operator and HSL user - shouldn't work.
* Also you shouldn't be able to open pre inspections in DRAFT with HSL user