### PR TITLE
327 Fix empty excel report error

### DIFF
--- a/src/report/DownloadReport.tsx
+++ b/src/report/DownloadReport.tsx
@@ -47,7 +47,9 @@ const DownloadReport = observer(
         },
       })
 
-      if (response.ok) {
+      // Require status 200 for the download. If the report is empty, the status
+      // will be 204 but the "ok" will still be true.
+      if (response.ok && response.status === 200) {
         let contentHeader = response.headers.get('Content-Disposition') || ''
         let regex = /filename="(.+?(?="))/g // Extract filename from header
         let name = (regex.exec(contentHeader) || ['', ''])[1] || 'raportti.xlsx'


### PR DESCRIPTION
Closes HSLdevcom/bultti#327

Fix to make the "report is empty" error show for the user when trying to download an empty report instead of giving a corrupted Excel file.

Server PR: