### PR TITLE
293 Update equipment color report schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -433,6 +433,7 @@ type EquipmentColorReportData {
   direction: String!
   equipmentExteriorColor: String!
   id: ID!
+  isTrunkRoute: Boolean!
   journeyEndTime: String!
   journeyStartTime: String!
   registryNr: String!
@@ -886,6 +887,7 @@ type ObservedEquipmentColorReportData {
   dayType: String!
   direction: String!
   id: ID!
+  isTrunkRoute: Boolean!
   journeyEndTime: String!
   journeyKilometers: Float!
   journeyStartTime: String!
@@ -1308,7 +1310,6 @@ type Query {
   adCoverSanctionsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): AdCoverSanctionsReport
   allDeviationsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): DeviationsReport
   allInspectionDates: [InspectionDate!]!
-  allInspections(inspectionType: InspectionType!): [Inspection!]!
   blockDeviationsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): BlockDeviationsReport
   contract(contractId: String!): Contract
   contractProcurementUnitOptions(contractId: String!, endDate: BulttiDate!, operatorId: Int!, startDate: BulttiDate!): [ProcurementUnitOption!]!
@@ -1324,15 +1325,12 @@ type Query {
   departureBlocksReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): DepartureBlocksReport
   earlyTimingStopDeparturesReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EarlyTimingStopDeparturesReport
   emissionClassExecutionReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EmissionClassExecutionReport
-  equipment: [Equipment!]!
-  equipmentByOperator(operatorId: Int!): [Equipment!]!
   equipmentCatalogue(equipmentCatalogueId: String!): EquipmentCatalogue
   equipmentCatalogueByOperator(operatorId: Int!): [EquipmentCatalogue!]!
   equipmentColorReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EquipmentColorReport
   equipmentDefectObservations(inspectionId: String!): [EquipmentDefect!]!
   equipmentTypeReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EquipmentTypeReport
   executionRequirementForProcurementUnit(inspectionId: String!, procurementUnitId: String!): PlannedUnitExecutionRequirement
-  executionRequirementsByOperator(operatorId: Int!): [PlannedUnitExecutionRequirement!]!
   executionRequirementsForPreInspectionAreas(inspectionId: String!): [PlannedAreaExecutionRequirement!]!
   executionRequirementsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): ExecutionRequirementsReport
   executionSchemaStats(executionRequirementId: String!): ExecutionSchemaStats

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -6168,6 +6168,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isTrunkRoute",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "equipmentExteriorColor",
             "description": null,
             "args": [],
@@ -14174,6 +14190,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isTrunkRoute",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "observedExteriorColor",
             "description": null,
             "args": [],
@@ -19896,47 +19928,6 @@
         "description": null,
         "fields": [
           {
-            "name": "executionRequirementsByOperator",
-            "description": null,
-            "args": [
-              {
-                "name": "operatorId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "PlannedUnitExecutionRequirement",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "executionRequirementForProcurementUnit",
             "description": null,
             "args": [
@@ -20304,71 +20295,6 @@
               "kind": "OBJECT",
               "name": "Equipment",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "equipment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Equipment",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "equipmentByOperator",
-            "description": null,
-            "args": [
-              {
-                "name": "operatorId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Equipment",
-                    "ofType": null
-                  }
-                }
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -23354,47 +23280,6 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "UNION",
-                    "name": "Inspection",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "allInspections",
-            "description": null,
-            "args": [
-              {
-                "name": "inspectionType",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "InspectionType",
                     "ofType": null
                   }
                 },

--- a/src/report/reportQueryFragments.ts
+++ b/src/report/reportQueryFragments.ts
@@ -120,6 +120,7 @@ export const reportQueryFragments = {
     fragment ObservedEquipmentColorFragment on ObservedEquipmentColorReportData {
       ${observedDepartureReportBaseFragment}
       registryNr
+      isTrunkRoute
       observedExteriorColor
       journeyKilometers
       procurementUnitId
@@ -218,6 +219,7 @@ export const reportQueryFragments = {
     fragment EquipmentColorFragment on EquipmentColorReportData {
       ${departureReportBaseFragment}
       registryNr
+      isTrunkRoute
       equipmentExteriorColor
     }
   `,

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -494,6 +494,7 @@ export type EquipmentColorReportData = {
   direction: Scalars['String']
   trackReason: TrackReason
   registryNr: Scalars['String']
+  isTrunkRoute: Scalars['Boolean']
   equipmentExteriorColor: Scalars['String']
 }
 
@@ -1297,6 +1298,7 @@ export type ObservedEquipmentColorReportData = {
   sanctionAmount?: Maybe<Scalars['Float']>
   procurementUnitId: Scalars['String']
   registryNr: Scalars['String']
+  isTrunkRoute: Scalars['Boolean']
   observedExteriorColor: Scalars['String']
   journeyKilometers: Scalars['Float']
 }
@@ -1749,7 +1751,6 @@ export type ProcurementUnitRoute = {
 
 export type Query = {
   __typename?: 'Query'
-  executionRequirementsByOperator: Array<PlannedUnitExecutionRequirement>
   executionRequirementForProcurementUnit?: Maybe<PlannedUnitExecutionRequirement>
   executionSchemaStats?: Maybe<ExecutionSchemaStats>
   operator?: Maybe<Operator>
@@ -1759,8 +1760,6 @@ export type Query = {
   procurementUnit: ProcurementUnit
   procurementUnitsByOperator: Array<ProcurementUnit>
   singleEquipment?: Maybe<Equipment>
-  equipment: Array<Equipment>
-  equipmentByOperator: Array<Equipment>
   queryEquipmentFromSource?: Maybe<Equipment>
   equipmentCatalogue?: Maybe<EquipmentCatalogue>
   equipmentCatalogueByOperator: Array<EquipmentCatalogue>
@@ -1814,15 +1813,10 @@ export type Query = {
   inspection: Inspection
   inspectionsByOperator: Array<Inspection>
   currentInspectionsByOperatorAndSeason: Array<Inspection>
-  allInspections: Array<Inspection>
   inspectionsTimeline: Array<InspectionTimelineItem>
   inspectionUserRelations: Array<InspectionUserRelation>
   equipmentDefectObservations: Array<EquipmentDefect>
   inspectionEquipmentDefectSanctions: SanctionsResponse
-}
-
-export type QueryExecutionRequirementsByOperatorArgs = {
-  operatorId: Scalars['Int']
 }
 
 export type QueryExecutionRequirementForProcurementUnitArgs = {
@@ -1860,10 +1854,6 @@ export type QueryProcurementUnitsByOperatorArgs = {
 
 export type QuerySingleEquipmentArgs = {
   equipmentId: Scalars['String']
-}
-
-export type QueryEquipmentByOperatorArgs = {
-  operatorId: Scalars['Int']
 }
 
 export type QueryQueryEquipmentFromSourceArgs = {
@@ -2130,10 +2120,6 @@ export type QueryCurrentInspectionsByOperatorAndSeasonArgs = {
   inspectionType: InspectionType
   seasonId: Scalars['String']
   operatorId: Scalars['Int']
-}
-
-export type QueryAllInspectionsArgs = {
-  inspectionType: InspectionType
 }
 
 export type QueryInspectionsTimelineArgs = {


### PR DESCRIPTION
Closes HSLdevcom/bultti#293

Schema updates to include the new trunk route field of equipment color report rows.

Server PR: https://github.com/HSLdevcom/bultti/pull/381