### PR TITLE
291 inspection date updates

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -794,7 +794,7 @@ type Mutation {
   removeTestData: Boolean!
   removeUnitExecutionRequirement(executionRequirementId: String!): Boolean!
   saveInspectionDepartureBlocks(inspectionId: String!): [OperatorBlockDeparture!]!
-  submitInspection(endDate: BulttiDate!, inspectionId: String!, startDate: BulttiDate!): Inspection!
+  submitInspection(inspectionId: String!): Inspection!
   toggleContractUserSubscribed(contractId: String!, userId: String!): ContractUserRelation
   toggleInspectionUserSubscribed(inspectionId: String!, userId: String!): InspectionUserRelation
   updateEquipment(equipmentId: String!): Equipment
@@ -1222,7 +1222,6 @@ type PlannedUnitExecutionRequirement {
 type PostInspection {
   billingPeriodMonth: BulttiDate
   createdAt: DateTime!
-  endDate: BulttiDate
   id: ID!
   inspectionDate: InspectionDate
   inspectionDateId: String
@@ -1232,25 +1231,21 @@ type PostInspection {
   inspectionType: InspectionType!
   linkedInspectionUpdateAvailable: Boolean
   linkedInspections: [LinkedInspectionForWeek!]
-  minStartDate: BulttiDate!
   name: String
   observedExecutionRequirements: [ObservedExecutionRequirement!]!
   operator: Operator!
   operatorId: Int!
   season: Season!
   seasonId: String!
-  startDate: BulttiDate
   status: InspectionStatus!
   updatedAt: DateTime!
   userRelations: [InspectionUserRelation!]
-  version: Int!
-  versionStackIdentifier: String
 }
 
 type PreInspection {
   areaExecutionRequirements: [PlannedAreaExecutionRequirement!]!
   createdAt: DateTime!
-  endDate: BulttiDate
+  endDate: BulttiDate!
   id: ID!
   inspectionEndDate: BulttiDate!
   inspectionErrors: [ValidationErrorData!]
@@ -1262,7 +1257,7 @@ type PreInspection {
   operatorId: Int!
   season: Season!
   seasonId: String!
-  startDate: BulttiDate
+  startDate: BulttiDate!
   status: InspectionStatus!
   unitExecutionRequirements: [PlannedUnitExecutionRequirement!]!
   updatedAt: DateTime!
@@ -1308,7 +1303,6 @@ type Query {
   adCoverSanctionsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): AdCoverSanctionsReport
   allDeviationsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): DeviationsReport
   allInspectionDates: [InspectionDate!]!
-  allInspections(inspectionType: InspectionType!): [Inspection!]!
   blockDeviationsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): BlockDeviationsReport
   contract(contractId: String!): Contract
   contractProcurementUnitOptions(contractId: String!, endDate: BulttiDate!, operatorId: Int!, startDate: BulttiDate!): [ProcurementUnitOption!]!
@@ -1324,15 +1318,12 @@ type Query {
   departureBlocksReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): DepartureBlocksReport
   earlyTimingStopDeparturesReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EarlyTimingStopDeparturesReport
   emissionClassExecutionReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EmissionClassExecutionReport
-  equipment: [Equipment!]!
-  equipmentByOperator(operatorId: Int!): [Equipment!]!
   equipmentCatalogue(equipmentCatalogueId: String!): EquipmentCatalogue
   equipmentCatalogueByOperator(operatorId: Int!): [EquipmentCatalogue!]!
   equipmentColorReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EquipmentColorReport
   equipmentDefectObservations(inspectionId: String!): [EquipmentDefect!]!
   equipmentTypeReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): EquipmentTypeReport
   executionRequirementForProcurementUnit(inspectionId: String!, procurementUnitId: String!): PlannedUnitExecutionRequirement
-  executionRequirementsByOperator(operatorId: Int!): [PlannedUnitExecutionRequirement!]!
   executionRequirementsForPreInspectionAreas(inspectionId: String!): [PlannedAreaExecutionRequirement!]!
   executionRequirementsReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): ExecutionRequirementsReport
   executionSchemaStats(executionRequirementId: String!): ExecutionSchemaStats

--- a/schema.graphql
+++ b/schema.graphql
@@ -633,7 +633,7 @@ type InspectionStatusUpdate {
   inspectionStartDate: BulttiDate!
   startDate: BulttiDate
   status: InspectionStatus!
-  version: Int!
+  version: Int
 }
 
 type InspectionTimelineItem {
@@ -642,7 +642,7 @@ type InspectionTimelineItem {
   inspectionStartDate: BulttiDate!
   operatorName: String!
   seasonId: String!
-  version: Int!
+  version: Int
 }
 
 type InspectionUserRelation {

--- a/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
+++ b/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
@@ -29,7 +29,7 @@ import { RequirementsTableLayout } from './executionRequirementUtils'
 import { text, Text } from '../util/translate'
 import { useQueryData } from '../util/useQueryData'
 import PlannedExecutionStats from './PlannedExecutionStats'
-import { useHasAdminAccessRights } from '../util/userRoles'
+import { isPreInspection } from '../inspection/inspectionUtils'
 
 const ProcurementUnitExecutionRequirementView = styled.div<{ isInvalid: boolean }>`
   margin-bottom: 2rem;
@@ -181,7 +181,12 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
     )
 
     const inspectionStartDate = useMemo(
-      () => (inspection?.startDate ? parseISO(inspection.startDate) : new Date()),
+      () =>
+        !inspection
+          ? undefined
+          : isPreInspection(inspection)
+          ? parseISO(inspection.startDate)
+          : parseISO(inspection?.inspectionStartDate),
       [inspection]
     )
 
@@ -238,7 +243,7 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
           <PlannedExecutionStats executionRequirement={procurementUnitRequirement} />
         )}
         <LoadingDisplay loading={requirementsLoading} />
-        {procurementUnitRequirement ? (
+        {procurementUnitRequirement && inspectionStartDate ? (
           <>
             <SubHeading>
               <Text>executionRequirement_equipmentList</Text>

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -12785,38 +12785,6 @@
             "description": null,
             "args": [
               {
-                "name": "endDate",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "BulttiDate",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "startDate",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "BulttiDate",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "inspectionId",
                 "description": null,
                 "type": {
@@ -18754,22 +18722,6 @@
             "deprecationReason": null
           },
           {
-            "name": "version",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "inspectionStartDate",
             "description": null,
             "args": [],
@@ -18797,58 +18749,6 @@
                 "name": "BulttiDate",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startDate",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "BulttiDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endDate",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "BulttiDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "minStartDate",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "BulttiDate",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "versionStackIdentifier",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19153,22 +19053,6 @@
             "deprecationReason": null
           },
           {
-            "name": "version",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "inspectionStartDate",
             "description": null,
             "args": [],
@@ -19205,9 +19089,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "BulttiDate",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19217,9 +19105,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "BulttiDate",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BulttiDate",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19248,6 +19140,22 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19896,47 +19804,6 @@
         "description": null,
         "fields": [
           {
-            "name": "executionRequirementsByOperator",
-            "description": null,
-            "args": [
-              {
-                "name": "operatorId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "PlannedUnitExecutionRequirement",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "executionRequirementForProcurementUnit",
             "description": null,
             "args": [
@@ -20304,71 +20171,6 @@
               "kind": "OBJECT",
               "name": "Equipment",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "equipment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Equipment",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "equipmentByOperator",
-            "description": null,
-            "args": [
-              {
-                "name": "operatorId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Equipment",
-                    "ofType": null
-                  }
-                }
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -23354,47 +23156,6 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "UNION",
-                    "name": "Inspection",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "allInspections",
-            "description": null,
-            "args": [
-              {
-                "name": "inspectionType",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "InspectionType",
                     "ofType": null
                   }
                 },

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -9246,13 +9246,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -9353,13 +9349,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -75,10 +75,7 @@ export const createGraphqlClient = (onAuthError: () => unknown = () => {}) => {
     typePolicies: {
       Query: {
         fields: {
-          currentPreInspectionsByOperatorAndSeason: {
-            merge: cacheMerge,
-          },
-          currentPostInspectionsByOperatorAndSeason: {
+          currentInspectionsByOperatorAndSeason: {
             merge: cacheMerge,
           },
           availableDayTypes: {

--- a/src/inspection/InspectionActions.tsx
+++ b/src/inspection/InspectionActions.tsx
@@ -53,7 +53,7 @@ export type PropTypes = {
   isEditingAllowed?: boolean
 }
 
-// TODO: Make a InspectionActions folder, put all action buttons seperately there to their own files to improve readability
+// TODO: Make a InspectionActions folder, separate action buttons into their own files to improve readability
 const InspectionActions = observer(
   ({ inspection, onRefresh, className, style, isEditingAllowed = true }: PropTypes) => {
     var [globalSeason, setGlobalSeason] = useStateValue('globalSeason')
@@ -124,8 +124,6 @@ const InspectionActions = observer(
       await submitInspection({
         variables: {
           inspectionId: inspection.id,
-          startDate: inspection.startDate,
-          endDate: inspection.endDate,
         },
       })
 

--- a/src/inspection/InspectionCard.tsx
+++ b/src/inspection/InspectionCard.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import { observer } from 'mobx-react-lite'
-import { getInspectionStatusColor, getInspectionStatusName } from './inspectionUtils'
+import {
+  getInspectionStatusColor,
+  getInspectionStatusName,
+  isPreInspection,
+} from './inspectionUtils'
 import { getReadableDate } from '../util/formatDate'
 import InspectionActions from './InspectionActions'
 import { Inspection, InspectionStatus } from '../schema-types'
@@ -116,18 +120,20 @@ const InspectionCard: React.FC<PropTypes> = observer(
               {inspection.operator.operatorName}, {inspection.seasonId}
             </InspectionTitle>
           )}
-          <InspectionVersion>{inspection.version}</InspectionVersion>
           <InspectionStatusDisplay status={inspection.status}>
             {getInspectionStatusName(inspection.status)}
           </InspectionStatusDisplay>
-          {inspection.startDate && inspection.endDate && (
-            <InspectionPeriodDisplay>
-              <DateTitle>
-                <Text>inspection_inspectionValidPeriod</Text>
-              </DateTitle>
-              <StartDate>{getReadableDate(inspection.startDate)}</StartDate>
-              <EndDate>{getReadableDate(inspection.endDate)}</EndDate>
-            </InspectionPeriodDisplay>
+          {isPreInspection(inspection) && (
+            <>
+              <InspectionVersion>{inspection.version}</InspectionVersion>
+              <InspectionPeriodDisplay>
+                <DateTitle>
+                  <Text>inspection_inspectionValidPeriod</Text>
+                </DateTitle>
+                <StartDate>{getReadableDate(inspection.startDate)}</StartDate>
+                <EndDate>{getReadableDate(inspection.endDate)}</EndDate>
+              </InspectionPeriodDisplay>
+            </>
           )}
           <InspectionPeriodDisplay>
             <DateTitle>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -124,31 +124,33 @@ const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection
               onChange={onChangeInspectionDate}
             />
           </FlexRow>
-          <FieldLabel style={{ textTransform: 'uppercase' }}>
-            <Text>inspection_selectProductionDate</Text>
-          </FieldLabel>
           {isPreInspection(inspection) && (
-            <ProductionDatePickers>
-              <DatePicker
-                value={getDateString(inspectionValues.startDate)}
-                minDate={inspection.minStartDate}
-                maxDate={inspection.season.endDate}
-                onChange={(dateString: string | null) => {
-                  onUpdateValue('startDate', dateString)
-                }}
-                acceptableDayTypes={['Ma']}
-                disabled={inspection.status !== InspectionStatus.Draft}
-              />
-              <DatePicker
-                value={getDateString(inspectionValues.endDate)}
-                maxDate={inspection.season.endDate}
-                onChange={(dateString: string | null) => {
-                  onUpdateValue('endDate', dateString)
-                }}
-                acceptableDayTypes={['Su']}
-                disabled={inspection.status !== InspectionStatus.Draft}
-              />
-            </ProductionDatePickers>
+            <>
+              <FieldLabel style={{ textTransform: 'uppercase' }}>
+                <Text>inspection_selectProductionDate</Text>
+              </FieldLabel>
+              <ProductionDatePickers>
+                <DatePicker
+                  value={getDateString(inspectionValues.startDate)}
+                  minDate={inspection.minStartDate}
+                  maxDate={inspection.season.endDate}
+                  onChange={(dateString: string | null) => {
+                    onUpdateValue('startDate', dateString)
+                  }}
+                  acceptableDayTypes={['Ma']}
+                  disabled={inspection.status !== InspectionStatus.Draft}
+                />
+                <DatePicker
+                  value={getDateString(inspectionValues.endDate)}
+                  maxDate={inspection.season.endDate}
+                  onChange={(dateString: string | null) => {
+                    onUpdateValue('endDate', dateString)
+                  }}
+                  acceptableDayTypes={['Su']}
+                  disabled={inspection.status !== InspectionStatus.Draft}
+                />
+              </ProductionDatePickers>
+            </>
           )}
           <FlexRow>
             <ActionsWrapper>

--- a/src/inspection/InspectionConfig.tsx
+++ b/src/inspection/InspectionConfig.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite'
 import Input from '../common/input/Input'
 import { isEqual } from 'lodash'
 import { FormColumn } from '../common/components/form'
-import { Inspection, InspectionInput, InspectionStatus } from '../schema-types'
+import { Inspection, InspectionInput, InspectionStatus, InspectionType } from '../schema-types'
 import { MessageContainer, MessageView } from '../common/components/Messages'
 import { FlexRow, PageSection } from '../common/components/common'
 import { Button, ButtonStyle } from '../common/components/buttons/Button'
@@ -132,27 +132,29 @@ const InspectionConfig: React.FC<PropTypes> = observer(({ saveValues, inspection
           <FieldLabel style={{ textTransform: 'uppercase' }}>
             <Text>inspection_selectProductionDate</Text>
           </FieldLabel>
-          <ProductionDatePickers>
-            <DatePicker
-              value={getDateString(pendingInspectionInputValues.startDate)}
-              minDate={inspection.minStartDate}
-              maxDate={inspection.season.endDate}
-              onChange={(dateString: string | null) => {
-                onUpdateValue('startDate', dateString)
-              }}
-              acceptableDayTypes={['Ma']}
-              disabled={inspection.status !== InspectionStatus.Draft}
-            />
-            <DatePicker
-              value={getDateString(pendingInspectionInputValues.endDate)}
-              maxDate={inspection.season.endDate}
-              onChange={(dateString: string | null) => {
-                onUpdateValue('endDate', dateString)
-              }}
-              acceptableDayTypes={['Su']}
-              disabled={inspection.status !== InspectionStatus.Draft}
-            />
-          </ProductionDatePickers>
+          {inspection.inspectionType === InspectionType.Pre && (
+            <ProductionDatePickers>
+              <DatePicker
+                value={getDateString(pendingInspectionInputValues.startDate)}
+                minDate={inspection.minStartDate}
+                maxDate={inspection.season.endDate}
+                onChange={(dateString: string | null) => {
+                  onUpdateValue('startDate', dateString)
+                }}
+                acceptableDayTypes={['Ma']}
+                disabled={inspection.status !== InspectionStatus.Draft}
+              />
+              <DatePicker
+                value={getDateString(pendingInspectionInputValues.endDate)}
+                maxDate={inspection.season.endDate}
+                onChange={(dateString: string | null) => {
+                  onUpdateValue('endDate', dateString)
+                }}
+                acceptableDayTypes={['Su']}
+                disabled={inspection.status !== InspectionStatus.Draft}
+              />
+            </ProductionDatePickers>
+          )}
           <FlexRow>
             <ActionsWrapper>
               <Button style={{ marginRight: '1rem' }} onClick={onSave} disabled={!isDirty}>

--- a/src/inspection/InspectionIndexItem.tsx
+++ b/src/inspection/InspectionIndexItem.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from '../common/icon/ArrowRight'
 import { SubHeading } from '../common/components/Typography'
 import DateRangeDisplay from '../common/components/DateRangeDisplay'
 import { Inspection } from '../schema-types'
+import { isPreInspection } from './inspectionUtils'
 
 const ContentRow = styled.div`
   display: flex;
@@ -100,7 +101,9 @@ export type PropTypes = {
 const InspectionIndexItem = observer(({ inspection, onClick }: PropTypes) => {
   return (
     <InspectionListItem key={inspection.id} onClick={onClick} as={onClick ? 'button' : 'div'}>
-      <InspectionVersion>{inspection.version}</InspectionVersion>
+      {isPreInspection(inspection) && (
+        <InspectionVersion>{inspection.version}</InspectionVersion>
+      )}
       <InspectionContentWrapper>
         <ContentRow>
           {inspection.name ? (
@@ -110,10 +113,12 @@ const InspectionIndexItem = observer(({ inspection, onClick }: PropTypes) => {
               {inspection.operator.operatorName} / {inspection.seasonId}
             </InspectionTitle>
           )}
-          <InspectionDates
-            startDate={inspection.startDate || ''}
-            endDate={inspection.endDate || ''}
-          />
+          {isPreInspection(inspection) && (
+            <InspectionDates
+              startDate={inspection.startDate || ''}
+              endDate={inspection.endDate || ''}
+            />
+          )}
         </ContentRow>
         {inspection.name && (
           <ContentRow>

--- a/src/inspection/InspectionPreview.tsx
+++ b/src/inspection/InspectionPreview.tsx
@@ -22,7 +22,6 @@ const InspectionPreview: React.FC<PropTypes> = observer(({ inspection }) => {
       inspection: !!inspection,
       status: inspection?.status !== InspectionStatus.InProduction,
       operator: !!inspection?.operator,
-      startDate: !!inspection?.startDate,
       season: !!inspection?.season,
     }
   }, [inspection])

--- a/src/inspection/InspectionsList.tsx
+++ b/src/inspection/InspectionsList.tsx
@@ -141,7 +141,7 @@ const InspectionsList: React.FC<PropTypes> = ({
   seasons = orderBy(seasons, ['startDate', 'endDate'], ['desc', 'desc'])
 
   const seasonGroups = groupBy(
-    orderBy(inspections, ['startDate', 'version'], ['desc', 'desc']),
+    orderBy(inspections, ['inspectionStartDate'], ['desc', 'desc']),
     'seasonId'
   )
 

--- a/src/inspection/InspectionsList.tsx
+++ b/src/inspection/InspectionsList.tsx
@@ -2,8 +2,14 @@ import React, { useMemo } from 'react'
 import styled from 'styled-components/macro'
 import { get, groupBy, orderBy } from 'lodash'
 import InspectionItem from './InspectionItem'
-import { Inspection, InspectionStatus, InspectionType, Season } from '../schema-types'
-import { getInspectionTypeStrings } from './inspectionUtils'
+import {
+  Inspection,
+  InspectionStatus,
+  InspectionType,
+  PreInspection,
+  Season,
+} from '../schema-types'
+import { getInspectionTypeStrings, isPreInspection } from './inspectionUtils'
 import { isBetween } from '../util/isBetween'
 import { LoadingDisplay } from '../common/components/Loading'
 import { useSeasons } from '../util/useSeasons'
@@ -161,13 +167,15 @@ const InspectionsList: React.FC<PropTypes> = ({
           let { id: seasonId } = season
           let inspections: Inspection[] = get(seasonGroups, seasonId, [])
 
-          let maxProductionVersion = inspections.reduce(
-            (maxVersion, { version, status }) =>
-              status === InspectionStatus.InProduction && version > maxVersion
-                ? version
-                : maxVersion,
-            1
-          )
+          let maxProductionVersion = isPreInspection(inspections[0])
+            ? inspections.reduce((maxVersion, inspection) => {
+                let version = (inspection as PreInspection).version
+
+                return status === InspectionStatus.InProduction && version > maxVersion
+                  ? version
+                  : maxVersion
+              }, 1)
+            : 0
 
           let renderCurrentTemporalLocationInSeason =
             currentSeason?.id === seasonId && inspections.length === 0
@@ -195,6 +203,7 @@ const InspectionsList: React.FC<PropTypes> = ({
               {inspections.map((inspection) => {
                 let renderCurrentTemporalLocation =
                   currentSeason?.id === seasonId &&
+                  isPreInspection(inspection) &&
                   isBetween(currentDateString, inspection.startDate, inspection.endDate)
 
                 return (
@@ -209,7 +218,8 @@ const InspectionsList: React.FC<PropTypes> = ({
                       inspection={inspection}
                       onInspectionUpdated={onUpdate}
                       isCurrentlyInEffect={
-                        inspection.version === maxProductionVersion &&
+                        (!isPreInspection(inspection) ||
+                          inspection.version === maxProductionVersion) &&
                         inspection.status === InspectionStatus.InProduction
                       }
                     />

--- a/src/inspection/SelectInspection.tsx
+++ b/src/inspection/SelectInspection.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components/macro'
 import { observer } from 'mobx-react-lite'
-import { Inspection, InspectionType, UserRole } from '../schema-types'
+import { Inspection, InspectionType } from '../schema-types'
 import { orderBy } from 'lodash'
 import { FlexRow } from '../common/components/common'
 import { useStateValue } from '../state/useAppState'
@@ -18,7 +18,6 @@ import InspectionCard from './InspectionCard'
 import { Text } from '../util/translate'
 import { operatorIsValid } from '../common/input/SelectOperator'
 import { seasonIsValid } from '../common/input/SelectSeason'
-import { useHasAccessRights } from '../util/userRoles'
 
 const SelectInspectionView = styled.div`
   position: relative;

--- a/src/inspection/SelectInspection.tsx
+++ b/src/inspection/SelectInspection.tsx
@@ -149,13 +149,15 @@ const SelectInspection: React.FC<PropTypes> = observer(
                   </ItemContent>
                 </NewInspection>
               )}
-              {orderBy(inspections, 'version', 'desc').map((inspection) => (
-                <InspectionCard
-                  key={inspection.id}
-                  onRefresh={refetchInspections}
-                  inspection={inspection}
-                />
-              ))}
+              {orderBy(inspections, ['inspectionStartDate', 'version'], ['desc', 'desc']).map(
+                (inspection) => (
+                  <InspectionCard
+                    key={inspection.id}
+                    onRefresh={refetchInspections}
+                    inspection={inspection}
+                  />
+                )
+              )}
             </InspectionItems>
           </>
         )}

--- a/src/inspection/inspectionQueries.ts
+++ b/src/inspection/inspectionQueries.ts
@@ -37,14 +37,10 @@ export const lightPostInspectionFragment = gql`
     name
     createdAt
     updatedAt
-    startDate
-    endDate
     inspectionDateId
     inspectionStartDate
     inspectionEndDate
-    version
     status
-    minStartDate
     operatorId
     seasonId
     operator {
@@ -225,12 +221,8 @@ export const updateLinkedInspectionsMutation = gql`
 `
 
 export const submitInspectionMutation = gql`
-  mutation submitInspection(
-    $inspectionId: String!
-    $startDate: BulttiDate!
-    $endDate: BulttiDate!
-  ) {
-    submitInspection(inspectionId: $inspectionId, startDate: $startDate, endDate: $endDate) {
+  mutation submitInspection($inspectionId: String!) {
+    submitInspection(inspectionId: $inspectionId) {
       ...InspectionUnionFragment
     }
   }

--- a/src/page/InspectionReportIndexPage.tsx
+++ b/src/page/InspectionReportIndexPage.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro'
 import { observer } from 'mobx-react-lite'
 import {
   getInspectionTypeStrings,
+  isPreInspection,
   useFetchInspections,
   useNavigateToInspectionReports,
 } from '../inspection/inspectionUtils'
@@ -73,7 +74,8 @@ const InspectionReportIndexPage: React.FC<PropTypes> = observer(({ inspectionTyp
       if (
         selectedDate &&
         selectedDate.value !== 'kaikki' &&
-        selectedDate.value !== inspection.startDate
+        selectedDate.value !==
+          (isPreInspection(inspection) ? inspection.startDate : inspection.season.startDate)
       ) {
         return false
       }
@@ -87,10 +89,16 @@ const InspectionReportIndexPage: React.FC<PropTypes> = observer(({ inspectionTyp
   let startDateOptions = useMemo(
     () => [
       defaultSelectedDate,
-      ...inspectionsList.map((inspection: Inspection) => ({
-        value: inspection.startDate || '',
-        label: getReadableDate(inspection.startDate),
-      })),
+      ...inspectionsList.map((inspection: Inspection) => {
+        let startDate =
+          (isPreInspection(inspection) ? inspection.startDate : inspection.season.startDate) ||
+          ''
+
+        return {
+          value: startDate,
+          label: getReadableDate(startDate),
+        }
+      }),
     ],
     [inspectionsList]
   )

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -1180,8 +1180,6 @@ export type MutationUpdateInspectionArgs = {
 }
 
 export type MutationSubmitInspectionArgs = {
-  endDate: Scalars['BulttiDate']
-  startDate: Scalars['BulttiDate']
   inspectionId: Scalars['String']
 }
 
@@ -1661,13 +1659,8 @@ export type PostInspection = {
   inspectionType: InspectionType
   createdAt: Scalars['DateTime']
   updatedAt: Scalars['DateTime']
-  version: Scalars['Int']
   inspectionStartDate: Scalars['BulttiDate']
   inspectionEndDate: Scalars['BulttiDate']
-  startDate?: Maybe<Scalars['BulttiDate']>
-  endDate?: Maybe<Scalars['BulttiDate']>
-  minStartDate: Scalars['BulttiDate']
-  versionStackIdentifier?: Maybe<Scalars['String']>
   operatorId: Scalars['Int']
   operator: Operator
   seasonId: Scalars['String']
@@ -1690,13 +1683,13 @@ export type PreInspection = {
   inspectionType: InspectionType
   createdAt: Scalars['DateTime']
   updatedAt: Scalars['DateTime']
-  version: Scalars['Int']
   inspectionStartDate: Scalars['BulttiDate']
   inspectionEndDate: Scalars['BulttiDate']
-  startDate?: Maybe<Scalars['BulttiDate']>
-  endDate?: Maybe<Scalars['BulttiDate']>
+  startDate: Scalars['BulttiDate']
+  endDate: Scalars['BulttiDate']
   minStartDate: Scalars['BulttiDate']
   versionStackIdentifier?: Maybe<Scalars['String']>
+  version: Scalars['Int']
   operatorId: Scalars['Int']
   operator: Operator
   seasonId: Scalars['String']
@@ -1749,7 +1742,6 @@ export type ProcurementUnitRoute = {
 
 export type Query = {
   __typename?: 'Query'
-  executionRequirementsByOperator: Array<PlannedUnitExecutionRequirement>
   executionRequirementForProcurementUnit?: Maybe<PlannedUnitExecutionRequirement>
   executionSchemaStats?: Maybe<ExecutionSchemaStats>
   operator?: Maybe<Operator>
@@ -1759,8 +1751,6 @@ export type Query = {
   procurementUnit: ProcurementUnit
   procurementUnitsByOperator: Array<ProcurementUnit>
   singleEquipment?: Maybe<Equipment>
-  equipment: Array<Equipment>
-  equipmentByOperator: Array<Equipment>
   queryEquipmentFromSource?: Maybe<Equipment>
   equipmentCatalogue?: Maybe<EquipmentCatalogue>
   equipmentCatalogueByOperator: Array<EquipmentCatalogue>
@@ -1814,15 +1804,10 @@ export type Query = {
   inspection: Inspection
   inspectionsByOperator: Array<Inspection>
   currentInspectionsByOperatorAndSeason: Array<Inspection>
-  allInspections: Array<Inspection>
   inspectionsTimeline: Array<InspectionTimelineItem>
   inspectionUserRelations: Array<InspectionUserRelation>
   equipmentDefectObservations: Array<EquipmentDefect>
   inspectionEquipmentDefectSanctions: SanctionsResponse
-}
-
-export type QueryExecutionRequirementsByOperatorArgs = {
-  operatorId: Scalars['Int']
 }
 
 export type QueryExecutionRequirementForProcurementUnitArgs = {
@@ -1860,10 +1845,6 @@ export type QueryProcurementUnitsByOperatorArgs = {
 
 export type QuerySingleEquipmentArgs = {
   equipmentId: Scalars['String']
-}
-
-export type QueryEquipmentByOperatorArgs = {
-  operatorId: Scalars['Int']
 }
 
 export type QueryQueryEquipmentFromSourceArgs = {
@@ -2130,10 +2111,6 @@ export type QueryCurrentInspectionsByOperatorAndSeasonArgs = {
   inspectionType: InspectionType
   seasonId: Scalars['String']
   operatorId: Scalars['Int']
-}
-
-export type QueryAllInspectionsArgs = {
-  inspectionType: InspectionType
 }
 
 export type QueryInspectionsTimelineArgs = {

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -778,7 +778,7 @@ export type InspectionStatusUpdate = {
   inspectionEndDate: Scalars['BulttiDate']
   startDate?: Maybe<Scalars['BulttiDate']>
   endDate?: Maybe<Scalars['BulttiDate']>
-  version: Scalars['Int']
+  version?: Maybe<Scalars['Int']>
 }
 
 export type InspectionTimelineItem = {
@@ -788,7 +788,7 @@ export type InspectionTimelineItem = {
   seasonId: Scalars['String']
   inspectionStartDate: Scalars['BulttiDate']
   inspectionEndDate: Scalars['BulttiDate']
-  version: Scalars['Int']
+  version?: Maybe<Scalars['Int']>
 }
 
 export enum InspectionType {


### PR DESCRIPTION
Closes HSLdevcom/bultti#291

Server PR: https://github.com/HSLdevcom/bultti/pull/382

Hide the "production period" date inputs in the post-inspection config form. Schema updates.