### PR TITLE
326 Block operators from removing execution requirement equipment

### DIFF
--- a/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
+++ b/src/executionRequirement/ProcurementUnitExecutionRequirement.tsx
@@ -99,8 +99,6 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
       refreshExecutionRequirementForProcurementUnitMutation
     )
 
-    let [execRemoveExecutionRequirement] = useMutationData(removeExecutionRequirementMutation)
-
     let [updateWeeklyMeters, { loading: weeklyMetersUpdateLoading }] = useMutationData(
       weeklyMetersFromJoreMutation,
       {
@@ -149,22 +147,6 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
         update()
       }
     }, [procurementUnitRequirement, refreshExecutionRequirement, isEditable])
-
-    let removeExecutionRequirement = useCallback(async () => {
-      if (
-        isEditable &&
-        procurementUnitRequirement &&
-        confirm(text('executionRequirement_removeWarning'))
-      ) {
-        await execRemoveExecutionRequirement({
-          variables: {
-            requirementId: procurementUnitRequirement.id,
-          },
-        })
-
-        update()
-      }
-    }, [procurementUnitRequirement, execRemoveExecutionRequirement, update, isEditable])
 
     const onUpdateWeeklyMeters = useCallback(async () => {
       if (isEditable) {
@@ -262,7 +244,6 @@ const ProcurementUnitExecutionRequirement: React.FC<PropTypes> = observer(
                 onEquipmentChanged={update}
                 hasEquipment={equipment.length !== 0}
                 addEquipment={addEquipment}
-                removeAllEquipment={removeExecutionRequirement}
                 removeLabel={text('executionRequirement_remove')}
                 editableKeys={['percentageQuota']}
                 fieldLabels={equipmentColumnLabels}

--- a/src/executionRequirement/RequirementEquipmentList.tsx
+++ b/src/executionRequirement/RequirementEquipmentList.tsx
@@ -70,7 +70,7 @@ const RequirementEquipmentList: React.FC<PropTypes> = observer(
 
     const removeEquipment = useCallback(
       async (equipmentId: string) => {
-        if (isEditable) {
+        if (isEditable && isAdmin) {
           await execRemoveEquipment({
             variables: {
               equipmentId,
@@ -81,7 +81,7 @@ const RequirementEquipmentList: React.FC<PropTypes> = observer(
           await onEquipmentChanged()
         }
       },
-      [onEquipmentChanged, executionRequirement, execRemoveEquipment, isEditable]
+      [onEquipmentChanged, executionRequirement, execRemoveEquipment, isEditable, isAdmin]
     )
 
     let tableEquipmentRows = useMemo(
@@ -97,7 +97,7 @@ const RequirementEquipmentList: React.FC<PropTypes> = observer(
       <EquipmentList
         equipment={tableEquipmentRows}
         updateEquipment={updateEquipmentData}
-        removeEquipment={!isEditable ? undefined : removeEquipment}
+        removeEquipment={isEditable && isAdmin ? removeEquipment : undefined}
         startDate={startDate}
         columnLabels={equipmentColumnLabels}
         groupedColumnLabels={groupedEquipmentColumnLabels}

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -119,7 +119,7 @@
   "executionRequirement_statsEquipmentType": "Kalustotyyppi",
   "executionRequirement_statsEquipmentCount": "Kalustomäärä",
   "executionRequirement_statsKilometers": "Kilometrejä viikossa",
-  "executionRequirement_refreshEquipment": "Virkistä kalustoluettelosta",
+  "executionRequirement_refreshEquipment": "Palauta alkuperäinen kalustoluettelo",
   "executionRequirement_weeklyKilometers": "Viikkokilometrit",
   "executionRequirement_updateJoreKilometers": "Päivitä suoritteet JOREsta",
   "executionRequirement_equipmentList": "Suoritevaatimuksen ajoneuvot",


### PR DESCRIPTION
Closes HSLdevcom/bultti#326

Hides equipment remove button in execution requirements for operator users.

Server PR: https://github.com/HSLdevcom/bultti/pull/436