### PR TITLE
148 fix page routes

### DIFF
--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -181,7 +181,9 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
         </h1>
       </AppTitle>
       <SidebarScrollContainer>
-        <UserBar>{DEBUG ? <UserLink to="user">{userContent}</UserLink> : userContent}</UserBar>
+        <UserBar>
+          {DEBUG ? <UserLink to="/user">{userContent}</UserLink> : userContent}
+        </UserBar>
         <GlobalFilters>
           <GlobalOperatorFilter />
           <GlobalSeasonFilter />

--- a/src/common/components/Tabs.tsx
+++ b/src/common/components/Tabs.tsx
@@ -1,10 +1,12 @@
-import React, { Children, useMemo } from 'react'
+import React, { Children, useEffect, useMemo } from 'react'
 import { observer } from 'mobx-react-lite'
 import styled, { keyframes } from 'styled-components/macro'
 import compact from 'lodash/compact'
 import flow from 'lodash/flow'
-import { Route, Switch, useRouteMatch } from 'react-router-dom'
+import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 import LinkWithQuery from './LinkWithQuery'
+import { last } from 'lodash'
+import { useNavigate } from '../../util/urlValue'
 
 export const TabsWrapper = styled.div`
   display: grid;
@@ -146,6 +148,22 @@ const Tabs: React.FC<PropTypes> = decorate(
 
       return compact(childrenTabs)
     }, [validChildren])
+
+    let location = useLocation()
+    let navigate = useNavigate()
+
+    // Revert to the root tab if the current tab disappears.
+    useEffect(() => {
+      let currentTab = last(location.pathname.split('/'))
+
+      if (
+        currentTab &&
+        !tabs.some((tab) => tab.path === currentTab) &&
+        location.pathname !== url
+      ) {
+        navigate.replace(url)
+      }
+    }, [tabs, navigate, location, url])
 
     return (
       <TabsWrapper className={className}>


### PR DESCRIPTION
Closes HSLdevcom/bultti#437

Fixes inspection edit tab navigation, where the UI would disappear if the current tab disappears. Also fixes sidebar link to the user page.

Server PR: https://github.com/HSLdevcom/bultti/pull/438