### PR TITLE
397 worker status page

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1653,9 +1653,9 @@ type ValidationErrorData {
 
 type WorkerStatus {
   id: String!
-  params: String
-  taskStarted: DateTime
-  workingOnTask: String
+  taskName: String
+  taskParams: String
+  taskStartedAt: DateTime
 }
 
 enum ContractUserRelationType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1373,6 +1373,7 @@ type Query {
   unobservedDeparturesReport(filters: [InputFilterConfig!], inspectionId: String!, sort: [InputSortConfig!]): UnobservedDeparturesReport
   user(userId: Int!): User
   users: [User!]!
+  workerStatus: [WorkerStatus!]!
 }
 
 type ReportListItem {
@@ -1608,6 +1609,13 @@ type ValidationErrorData {
   objectId: String
   referenceKeys: [String!]
   type: InspectionValidationError!
+}
+
+type WorkerStatus {
+  id: String!
+  params: String
+  taskStarted: DateTime
+  workingOnTask: String
 }
 
 enum ContractUserRelationType {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import DevPage from './dev/DevPage'
 import { InspectionType } from './schema-types'
 import { DEBUG } from './constants'
 import { useUnsavedChangesPrompt } from './util/promptUnsavedChanges'
+import StatusPage from './page/StatusPage'
 
 const App: React.FC = observer(() => {
   const [authState, loading] = useAuth()
@@ -107,7 +108,12 @@ const App: React.FC = observer(() => {
         />
         <Route component={EditContractPage} path="/contract/:contractId" />
         <Route component={ContractPage} path="/contract" />
-        {hasAdminAccessRights && <Route component={DevPage} path="/dev-tools" />}
+        {hasAdminAccessRights && (
+          <>
+            <Route component={DevPage} path="/dev-tools" />
+            <Route component={StatusPage} path="/status" />
+          </>
+        )}
         <Route component={ProcurementUnitsPage} path="/procurement-units" />
       </Switch>
     </AppFrame>

--- a/src/common/components/AppSidebar.tsx
+++ b/src/common/components/AppSidebar.tsx
@@ -18,7 +18,7 @@ import { useMutationData } from '../../util/useMutationData'
 import { pickGraphqlData } from '../../util/pickGraphqlData'
 import { removeAuthToken } from '../../util/authToken'
 import { DEBUG } from '../../constants'
-import { useHasAdminAccessRights } from '../../util/userRoles'
+import { useHasAdminAccessRights, useIsTestUser } from '../../util/userRoles'
 import { useNavigate } from '../../util/urlValue'
 
 export const APP_TITLE_HEIGHT = 100
@@ -172,6 +172,8 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
     }
   }, [navigate])
 
+  let isTestUser = useIsTestUser()
+
   return (
     <AppSidebarView>
       <AppTitle to="/">
@@ -244,12 +246,22 @@ const AppSidebar: React.FC<AppSidebarProps> = observer(() => {
               <Menu fill="white" width="1rem" height="1rem" />
               <Text>reports</Text>
             </NavLink>
-            {hasAdminAccessRights && DEBUG && (
-              <NavLink to="/dev-tools">
-                <div>Dev tools</div>
-              </NavLink>
-            )}
           </NavCategory>
+          {hasAdminAccessRights && (
+            <NavCategory>
+              <CategoryTitle>
+                <Text>maintenance</Text>
+              </CategoryTitle>
+              <NavLink to="/status">
+                <div>System status</div>
+              </NavLink>
+              {isTestUser && (
+                <NavLink to="/dev-tools">
+                  <div>Dev tools</div>
+                </NavLink>
+              )}
+            </NavCategory>
+          )}
           <NavCategory>
             <Button
               style={{ color: 'white ', border: '1px solid white', margin: 'auto' }}

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -23576,6 +23576,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "workerStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkerStatus",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -27224,6 +27248,69 @@
           },
           {
             "name": "objectId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkerStatus",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workingOnTask",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "taskStarted",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "params",
             "description": null,
             "args": [],
             "type": {

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -27778,7 +27778,7 @@
             "deprecationReason": null
           },
           {
-            "name": "workingOnTask",
+            "name": "taskName",
             "description": null,
             "args": [],
             "type": {
@@ -27790,7 +27790,7 @@
             "deprecationReason": null
           },
           {
-            "name": "taskStarted",
+            "name": "taskStartedAt",
             "description": null,
             "args": [],
             "type": {
@@ -27802,7 +27802,7 @@
             "deprecationReason": null
           },
           {
-            "name": "params",
+            "name": "taskParams",
             "description": null,
             "args": [],
             "type": {

--- a/src/page/StatusPage.tsx
+++ b/src/page/StatusPage.tsx
@@ -15,9 +15,9 @@ const workerStatusQuery = gql`
   query workerStatus {
     workerStatus {
       id
-      taskStarted
-      workingOnTask
-      params
+      taskStartedAt
+      taskName
+      taskParams
     }
   }
 `
@@ -74,16 +74,16 @@ const StatusPage: React.FC = observer(({ children }) => {
             <WorkerStatusItem key={status.id}>
               <ItemSection>
                 <ItemSectionHeading>Task</ItemSectionHeading>
-                {status.workingOnTask}
+                {status.taskName}
               </ItemSection>
               <ItemSection>
                 <ItemSectionHeading>Started</ItemSectionHeading>
-                {status.taskStarted}
+                {status.taskStartedAt}
               </ItemSection>
               <ItemSection style={{ maxWidth: '33%' }}>
                 <ItemSectionHeading>Params</ItemSectionHeading>
                 <pre style={{ maxWidth: '100%', overflowX: 'scroll' }}>
-                  <code>{JSON.stringify(JSON.parse(status.params || ''), null, 2)}</code>
+                  <code>{JSON.stringify(JSON.parse(status.taskParams || ''), null, 2)}</code>
                 </pre>
               </ItemSection>
             </WorkerStatusItem>

--- a/src/page/StatusPage.tsx
+++ b/src/page/StatusPage.tsx
@@ -68,6 +68,7 @@ const StatusPage: React.FC = observer(({ children }) => {
               <Text>update</Text>
             </Button>
           </FlexRow>
+          {workerStatus.length === 0 && <div>Currently not working on any task.</div>}
 
           {workerStatus.map((status) => (
             <WorkerStatusItem key={status.id}>

--- a/src/page/StatusPage.tsx
+++ b/src/page/StatusPage.tsx
@@ -14,6 +14,7 @@ const workerStatusQuery = gql`
       id
       taskStarted
       workingOnTask
+      params
     }
   }
 `
@@ -32,7 +33,7 @@ const WorkerStatusItem = styled.div`
 `
 
 const ItemSection = styled.div`
-  flex: 1;
+  flex: 1 0 auto;
 `
 
 const ItemSectionHeading = styled.h5`
@@ -58,6 +59,12 @@ const StatusPage: React.FC = observer(({ children }) => {
               <ItemSection>
                 <ItemSectionHeading>Started</ItemSectionHeading>
                 {status.taskStarted}
+              </ItemSection>
+              <ItemSection style={{ maxWidth: '33%' }}>
+                <ItemSectionHeading>Params</ItemSectionHeading>
+                <pre style={{ maxWidth: '100%', overflowX: 'scroll' }}>
+                  <code>{JSON.stringify(JSON.parse(status.params || ''), null, 2)}</code>
+                </pre>
               </ItemSection>
             </WorkerStatusItem>
           ))}

--- a/src/page/StatusPage.tsx
+++ b/src/page/StatusPage.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { PageTitle } from '../common/components/PageTitle'
 import { SectionHeading } from '../common/components/Typography'
-import { Page, PageContainer, PageSection } from '../common/components/common'
+import { FlexRow, Page, PageContainer, PageSection } from '../common/components/common'
 import { gql } from '@apollo/client'
 import { useQueryData } from '../util/useQueryData'
 import styled from 'styled-components/macro'
 import { WorkerStatus } from '../schema-types'
+import { Button, ButtonSize, ButtonStyle } from '../common/components/buttons/Button'
+import { Text } from '../util/translate'
+import { LoadingDisplay } from '../common/components/Loading'
 
 const workerStatusQuery = gql`
   query workerStatus {
@@ -42,14 +45,30 @@ const ItemSectionHeading = styled.h5`
 `
 
 const StatusPage: React.FC = observer(({ children }) => {
-  let { data: workerStatus = [] } = useQueryData<WorkerStatus[]>(workerStatusQuery)
+  let {
+    data: workerStatus = [],
+    loading,
+    refetch,
+  } = useQueryData<WorkerStatus[]>(workerStatusQuery)
 
   return (
     <Page>
       <PageTitle>Status</PageTitle>
       <PageContainer>
         <PageSection>
-          <SectionHeading>Worker status</SectionHeading>
+          <LoadingDisplay loading={loading} />
+          <FlexRow>
+            <SectionHeading>Worker status</SectionHeading>
+            <Button
+              style={{ marginLeft: 'auto' }}
+              size={ButtonSize.SMALL}
+              buttonStyle={ButtonStyle.SECONDARY}
+              loading={loading}
+              onClick={() => refetch()}>
+              <Text>update</Text>
+            </Button>
+          </FlexRow>
+
           {workerStatus.map((status) => (
             <WorkerStatusItem key={status.id}>
               <ItemSection>

--- a/src/page/StatusPage.tsx
+++ b/src/page/StatusPage.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { observer } from 'mobx-react-lite'
+import { PageTitle } from '../common/components/PageTitle'
+import { SectionHeading } from '../common/components/Typography'
+import { Page, PageContainer, PageSection } from '../common/components/common'
+import { gql } from '@apollo/client'
+import { useQueryData } from '../util/useQueryData'
+import styled from 'styled-components/macro'
+import { WorkerStatus } from '../schema-types'
+
+const workerStatusQuery = gql`
+  query workerStatus {
+    workerStatus {
+      id
+      taskStarted
+      workingOnTask
+    }
+  }
+`
+
+const WorkerStatusItem = styled.div`
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--lighter-grey);
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`
+
+const ItemSection = styled.div`
+  flex: 1;
+`
+
+const ItemSectionHeading = styled.h5`
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+`
+
+const StatusPage: React.FC = observer(({ children }) => {
+  let { data: workerStatus = [] } = useQueryData<WorkerStatus[]>(workerStatusQuery)
+
+  return (
+    <Page>
+      <PageTitle>Status</PageTitle>
+      <PageContainer>
+        <PageSection>
+          <SectionHeading>Worker status</SectionHeading>
+          {workerStatus.map((status) => (
+            <WorkerStatusItem key={status.id}>
+              <ItemSection>
+                <ItemSectionHeading>Task</ItemSectionHeading>
+                {status.workingOnTask}
+              </ItemSection>
+              <ItemSection>
+                <ItemSectionHeading>Started</ItemSectionHeading>
+                {status.taskStarted}
+              </ItemSection>
+            </WorkerStatusItem>
+          ))}
+        </PageSection>
+      </PageContainer>
+    </Page>
+  )
+})
+
+export default StatusPage

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -1827,6 +1827,7 @@ export type Query = {
   inspectionUserRelations: Array<InspectionUserRelation>
   equipmentDefectObservations: Array<EquipmentDefect>
   inspectionEquipmentDefectSanctions: EquipmentDefectSanctionsResponse
+  workerStatus: Array<WorkerStatus>
 }
 
 export type QueryExecutionRequirementForProcurementUnitArgs = {
@@ -2492,4 +2493,12 @@ export type ValidationErrorData = {
   keys?: Maybe<Array<Scalars['String']>>
   referenceKeys?: Maybe<Array<Scalars['String']>>
   objectId?: Maybe<Scalars['String']>
+}
+
+export type WorkerStatus = {
+  __typename?: 'WorkerStatus'
+  id: Scalars['String']
+  workingOnTask?: Maybe<Scalars['String']>
+  taskStarted?: Maybe<Scalars['DateTime']>
+  params?: Maybe<Scalars['String']>
 }

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -2538,7 +2538,7 @@ export type ValidationErrorData = {
 export type WorkerStatus = {
   __typename?: 'WorkerStatus'
   id: Scalars['String']
-  workingOnTask?: Maybe<Scalars['String']>
-  taskStarted?: Maybe<Scalars['DateTime']>
-  params?: Maybe<Scalars['String']>
+  taskName?: Maybe<Scalars['String']>
+  taskStartedAt?: Maybe<Scalars['DateTime']>
+  taskParams?: Maybe<Scalars['String']>
 }

--- a/src/text/fi.json
+++ b/src/text/fi.json
@@ -45,6 +45,7 @@
   "reports": "Raportit",
   "preInspections": "Ennakkotarkastukset",
   "postInspections": "Jälkitarkastukset",
+  "maintenance": "Ylläpito",
   "executionRequirements": "Suoritevaatimukset",
   "departureBlocks": "Lähtöketjut",
   "vehicleId": "Kylkinumero",

--- a/src/util/userRoles.ts
+++ b/src/util/userRoles.ts
@@ -92,3 +92,16 @@ export function hasOperatorUserAccessRights(
     !!user && user.role === UserRole.Operator && (user.operatorIds || []).includes(operatorId)
   )
 }
+
+export function isTestUser(user: User | null | undefined) {
+  if (!user) {
+    return false
+  }
+
+  return user.hslIdGroups.includes('HSL-testing')
+}
+
+export function useIsTestUser() {
+  const [user] = useStateValue('user')
+  return isTestUser(user)
+}


### PR DESCRIPTION
Closes HSLdevcom/bultti#397

Add a maintenance nav section to the sidebar containing the Dev Page (for devs) and a Status page. The status page contains a Worker Status section listing currently running worker jobs.

Server PR: https://github.com/HSLdevcom/bultti/pull/439