### PR TITLE
456 logging in fixes

### DIFF
--- a/src/util/isNumeric.ts
+++ b/src/util/isNumeric.ts
@@ -1,11 +1,3 @@
-export const isNumeric = (value: unknown) => {
-  if (typeof value === 'number') {
-    return true
-  }
-
-  if (typeof value === 'string') {
-    return !isNaN(parseInt(value, 10)) || !isNaN(parseFloat(value))
-  }
-
-  return false
+export const isNumeric = (value: string | number) => {
+  return value != null && value !== '' && !isNaN(Number(value.toString()))
 }


### PR DESCRIPTION
Closes https://github.com/HSLdevcom/bultti/issues/456

* First problem solution: remove auth token from clear local storage if login fails so that user does not have to manually reset application memory from browser's console. Hopefully this solves the problem.
* So the second problem was that when logging in and code param started with a number, isNumber thought that the string was a number and tried to parse it. The fix for isNumber check taken from here:
https://stackoverflow.com/a/50376498/4282381